### PR TITLE
nb-langプロンプトを完全化＋3言語リファレンス実装（Phase 1動作検証済み）

### DIFF
--- a/cc-native-compiler-osaka-202605/README.md
+++ b/cc-native-compiler-osaka-202605/README.md
@@ -10,7 +10,7 @@
 
 - **実装言語の開発環境**（以下のいずれか）
   - Scala 3（`scala-cli` 推奨）
-  - TypeScript（Node.js 20+, `tsx` など）
+  - TypeScript（[Bun](https://bun.sh/) 1.0+、`bun run main.ts` で直実行）
   - Java（17 以上）
 - Claude Code のアカウントと動作確認済み環境
 - LLVM toolchain（`llc`, `clang` 等）

--- a/cc-native-compiler-osaka-202605/prompts/backend-strategy.md
+++ b/cc-native-compiler-osaka-202605/prompts/backend-strategy.md
@@ -7,72 +7,132 @@
 
 ## 方針：LLVM IR 経由
 
-`nb-lang` のコンパイラは、**LLVM IR を文字列として出力する**形で実装します。
+`nb-lang` のコンパイラは、**LLVM IR を文字列として出力する** 形で実装します。
 実装言語は **Scala 3 / TypeScript / Java** のいずれかを選べます。
 
 理由：
+
 - LLVM IR はテキスト形式で、どの言語でも文字列連結で生成できる
-- レジスタ割り当て・最適化・機械語生成は **`llc` / `clang`** に完全に任せられる
-- macOS (ARM64) / Linux (x86-64) / WSL2 の **環境差を LLVM が吸収**する
+- レジスタ割り当て・最適化・機械語生成は `llc` / `clang` に完全に任せられる
+- 環境ごとに `target triple` を変えれば、macOS arm64 / Linux x86-64 / WSL2 で同じバックエンドが動く
 
 ## 出力とビルドの流れ
 
 ```
 nb-lang source (example.nb)
   └─> [自作コンパイラ（Scala 3 / TS / Java）]
-       ├─ Lexer
-       ├─ Parser
-       ├─ AST
-       └─ CodeGen ──> example.ll (LLVM IR テキスト)
-                        │
-                        └─> $ clang example.ll -o a.out
-                              └─> $ ./a.out
+       └─ Lexer → Parser → AST → CodeGen
+                                    │
+                                    ▼
+                               example.ll (LLVM IR テキスト)
+                                    │
+                                    └─> $ clang example.ll -o a.out
+                                          └─> $ ./a.out
 ```
 
-## 生成する LLVM IR の最小パターン
+## 環境別 target triple（重要：2 バリアント）
 
-### `print(42);` に相当
+実行環境ごとに先頭の `target triple` を切り替える必要があります。
+
+| 環境 | target triple |
+|------|---------------|
+| macOS (Apple Silicon) | `arm64-apple-macosx15.0.0` |
+| Linux x86-64 / WSL2 | `x86_64-pc-linux-gnu` |
+
+triple が現環境と違うと clang が override 警告を出します。実装では `uname` 等で検出して
+書き分けるか、`process.platform` で分岐するのが楽。
+
+```scala
+// Scala 3 例
+val triple = System.getProperty("os.name") match
+  case s if s.startsWith("Mac") => "arm64-apple-macosx15.0.0"
+  case _ => "x86_64-pc-linux-gnu"
+```
+
+```typescript
+// TypeScript 例
+const triple = process.platform === "darwin"
+  ? "arm64-apple-macosx15.0.0"
+  : "x86_64-pc-linux-gnu";
+```
+
+```java
+// Java 例
+String triple = System.getProperty("os.name").startsWith("Mac")
+    ? "arm64-apple-macosx15.0.0"
+    : "x86_64-pc-linux-gnu";
+```
+
+## LLVM 15+ の opaque pointer（重要）
+
+現代の LLVM（15+）では typed pointer (`i8*`, `[5 x i8]*`) は **廃止** され、
+**全てのポインタ型は `ptr`** に統一されています。
+
+古い資料に出てくる `i8*` や `getelementptr [5 x i8], [5 x i8]* @fmt, i32 0, i32 0`
+のような書き方は Apple clang 16 以降で警告が出るため、**全て `ptr` に統一**してください。
+
+```llvm
+; 古い（NG）
+declare i32 @printf(i8*, ...)
+%0 = call i32 (i8*, ...) @printf(i8* getelementptr ([5 x i8], [5 x i8]* @fmt, i32 0, i32 0), i64 42)
+
+; 新しい（OK）
+declare i32 @printf(ptr, ...)
+%0 = call i32 (ptr, ...) @printf(ptr @fmt, i64 42)
+```
+
+## Hello World — 完全動作例
+
+これを `hello.ll` に保存して `clang hello.ll -o hello && ./hello` で `42` が出る：
 
 ```llvm
 ; ModuleID = 'nb-lang'
-target triple = "arm64-apple-macosx14.0.0"   ; 環境に応じて差し替え
+target triple = "arm64-apple-macosx15.0.0"   ; Linux なら "x86_64-pc-linux-gnu"
 
 @fmt = private constant [5 x i8] c"%ld\0A\00"
-declare i32 @printf(i8*, ...)
+declare i32 @printf(ptr, ...)
 
 define i32 @main() {
 entry:
-  %0 = call i32 (i8*, ...) @printf(i8* getelementptr ([5 x i8], [5 x i8]* @fmt, i32 0, i32 0), i64 42)
+  call i32 (ptr, ...) @printf(ptr @fmt, i64 42)
   ret i32 0
 }
 ```
 
-### 変数 (alloca + load/store)
+**動作検証済み**：
+- macOS arm64 (Apple clang 16.0.0) ✓
+- Linux x86-64 / WSL2: target triple 差し替えで通る想定（要 ryzen-laptop で検証）
+
+---
+
+## Phase 1 — 整数演算・変数・if・while・print
+
+### 変数 (alloca + store/load)
 
 ```llvm
-  %x.addr = alloca i64
-  store i64 10, i64* %x.addr
-  %x.val = load i64, i64* %x.addr
+%x = alloca i64, align 8
+store i64 10, ptr %x
+%v = load i64, ptr %x
 ```
 
 ### 演算 (add / sub / mul / sdiv / srem)
 
 ```llvm
-  %sum = add i64 %a, %b
-  %diff = sub i64 %a, %b
-  %prod = mul i64 %a, %b
-  %quot = sdiv i64 %a, %b
-  %rem = srem i64 %a, %b
+%sum  = add  i64 %a, %b
+%diff = sub  i64 %a, %b
+%prod = mul  i64 %a, %b
+%quot = sdiv i64 %a, %b
+%rem  = srem i64 %a, %b
 ```
 
 ### 比較 (icmp)
 
 ```llvm
-  %cond = icmp slt i64 %a, %b   ; signed less than
-  ; eq, ne, slt, sle, sgt, sge
+%cond = icmp slt i64 %a, %b   ; signed less than
+; eq, ne, slt, sle, sgt, sge
 ```
 
-### 制御フロー (br)
+### 制御フロー (br) — if/else
 
 ```llvm
   br i1 %cond, label %then, label %else
@@ -86,7 +146,7 @@ end:
   ; ...
 ```
 
-### `while` ループ
+### while ループ
 
 ```llvm
   br label %cond
@@ -100,20 +160,247 @@ exit:
   ; ...
 ```
 
+### Phase 1 統合例（1〜10 の和、`./a.out` で `55` 出力）
+
+**動作検証済み（macOS arm64）**
+
+```llvm
+; ModuleID = 'nb-lang'
+target triple = "arm64-apple-macosx15.0.0"
+
+@fmt = private constant [5 x i8] c"%ld\0A\00"
+declare i32 @printf(ptr, ...)
+
+define i32 @main() {
+entry:
+  %n = alloca i64, align 8
+  %sum = alloca i64, align 8
+  %i = alloca i64, align 8
+  store i64 10, ptr %n
+  store i64 0, ptr %sum
+  store i64 1, ptr %i
+  br label %cond
+
+cond:
+  %i.val = load i64, ptr %i
+  %n.val = load i64, ptr %n
+  %c = icmp sle i64 %i.val, %n.val
+  br i1 %c, label %body, label %exit
+
+body:
+  %sum.val = load i64, ptr %sum
+  %i.val2 = load i64, ptr %i
+  %newsum = add i64 %sum.val, %i.val2
+  store i64 %newsum, ptr %sum
+  %i.val3 = load i64, ptr %i
+  %newi = add i64 %i.val3, 1
+  store i64 %newi, ptr %i
+  br label %cond
+
+exit:
+  %final = load i64, ptr %sum
+  call i32 (ptr, ...) @printf(ptr @fmt, i64 %final)
+  ret i32 0
+}
+```
+
+---
+
+## Phase 2 — 関数定義・呼び出し
+
+関数定義は `define`、呼び出しは `call`。`ret` で値を返す。再帰も普通に書ける。
+
+### 関数定義の書き方ポイント
+
+- 引数：`define i64 @func(i64 %a, i64 %b)`
+- 戻り値型：`define <ret_ty> @name(...)`
+- `ret void` で戻り値なし
+- 末尾で `ret` を必ず置く（`alloca` した変数は関数終了で自動解放）
+
+### 階乗の例（`fact(5)` で `120` 出力）
+
+**動作検証済み（macOS arm64）**
+
+```llvm
+; ModuleID = 'nb-lang'
+target triple = "arm64-apple-macosx15.0.0"
+
+@fmt = private constant [5 x i8] c"%ld\0A\00"
+declare i32 @printf(ptr, ...)
+
+define i64 @fact(i64 %n) {
+entry:
+  %cmp = icmp sle i64 %n, 1
+  br i1 %cmp, label %then, label %else
+
+then:
+  ret i64 1
+
+else:
+  %sub = sub i64 %n, 1
+  %rec = call i64 @fact(i64 %sub)
+  %mul = mul i64 %n, %rec
+  ret i64 %mul
+}
+
+define i32 @main() {
+entry:
+  %r = call i64 @fact(i64 5)
+  call i32 (ptr, ...) @printf(ptr @fmt, i64 %r)
+  ret i32 0
+}
+```
+
+---
+
+## Phase 3 — 文字列・リスト
+
+### 文字列リテラル（`hello` 出力）
+
+**動作検証済み（macOS arm64）**
+
+```llvm
+; ModuleID = 'nb-lang'
+target triple = "arm64-apple-macosx15.0.0"
+
+@strfmt = private constant [4 x i8] c"%s\0A\00"
+@hello = private constant [6 x i8] c"hello\00"
+declare i32 @printf(ptr, ...)
+
+define i32 @main() {
+entry:
+  call i32 (ptr, ...) @printf(ptr @strfmt, ptr @hello)
+  ret i32 0
+}
+```
+
+ポイント：
+
+- 文字列は `private constant [N x i8] c"..."` でグローバルに置く
+- `\0A` は LF (0x0A)、`\00` は終端 NUL
+- 配列長 `N` は **NUL 終端を含む**バイト数（`hello` は 6 = `h`,`e`,`l`,`l`,`o`,`\0`）
+
+### リスト（malloc ベース動的配列、`[1,2,3,4,5]` の和で `15` 出力）
+
+**動作検証済み（macOS arm64）**
+
+```llvm
+; ModuleID = 'nb-lang'
+target triple = "arm64-apple-macosx15.0.0"
+
+@fmt = private constant [5 x i8] c"%ld\0A\00"
+declare i32 @printf(ptr, ...)
+declare ptr @malloc(i64)
+
+define i32 @main() {
+entry:
+  ; xs = malloc(5 * 8 bytes)
+  %xs = call ptr @malloc(i64 40)
+  %p0 = getelementptr i64, ptr %xs, i64 0
+  store i64 1, ptr %p0
+  %p1 = getelementptr i64, ptr %xs, i64 1
+  store i64 2, ptr %p1
+  %p2 = getelementptr i64, ptr %xs, i64 2
+  store i64 3, ptr %p2
+  %p3 = getelementptr i64, ptr %xs, i64 3
+  store i64 4, ptr %p3
+  %p4 = getelementptr i64, ptr %xs, i64 4
+  store i64 5, ptr %p4
+
+  %total = alloca i64
+  %i = alloca i64
+  store i64 0, ptr %total
+  store i64 0, ptr %i
+  br label %cond
+
+cond:
+  %i.val = load i64, ptr %i
+  %c = icmp slt i64 %i.val, 5
+  br i1 %c, label %body, label %exit
+
+body:
+  %total.val = load i64, ptr %total
+  %i.val2 = load i64, ptr %i
+  %elemptr = getelementptr i64, ptr %xs, i64 %i.val2
+  %elem = load i64, ptr %elemptr
+  %newtotal = add i64 %total.val, %elem
+  store i64 %newtotal, ptr %total
+  %newi = add i64 %i.val2, 1
+  store i64 %newi, ptr %i
+  br label %cond
+
+exit:
+  %final = load i64, ptr %total
+  call i32 (ptr, ...) @printf(ptr @fmt, i64 %final)
+  ret i32 0
+}
+```
+
+ポイント：
+
+- リストは `malloc(要素数 * 要素サイズ)` で確保（i64 要素なら要素サイズは 8）
+- 要素アクセスは `getelementptr i64, ptr %xs, i64 <index>` でアドレス取得
+- `free` は省略（短命プログラム前提、GC は実装しない）
+- 異なる要素型のリスト（`list<string>` 等）が必要なら、要素型に応じてサイズを変える
+
+---
+
+## ビルドコマンドと環境差
+
+### macOS (Apple Silicon)
+
+```bash
+clang hello.ll -o hello
+./hello
+```
+
+何もオプションいらない。Apple clang が SDK パスやリンカを自動解決。
+
+### Linux x86-64 / WSL2
+
+```bash
+clang hello.ll -o hello
+./hello
+```
+
+通常はこれで通る。distro によっては以下のオプションが必要なことがあります：
+
+- 一部 Ubuntu: `-no-pie`（PIE 関連のリンクエラーが出たら付ける）
+- glibc 不一致: `-fuse-ld=lld` で代替リンカを使うと解消することあり
+
+### IR 最適化（任意）
+
+```bash
+clang -O2 hello.ll -o hello   # 最適化レベル指定
+```
+
+最初は `-O0` 相当（無指定）で十分。動いてから `-O2` を試す。
+
+---
+
 ## 詰まりやすい箇所
 
-1. **target triple** が環境で違う
-   - macOS ARM: `arm64-apple-macosx14.0.0`
-   - Linux x86-64: `x86_64-pc-linux-gnu`
-   - 省略してもビルドは通ることが多い（`clang` が推測する）
+1. **target triple バージョンの不一致**
+   - macOS は `arm64-apple-macosx<実 SDK バージョン>`。違うバージョンだと警告
+   - 警告無視で動くが、気になるなら現行 SDK バージョンを取得して書く
 
-2. **SSA 形式のラベル管理**
+2. **opaque pointer (`ptr`) と typed pointer (`i8*`) の混在**
+   - Apple clang 16+ は opaque pointer 前提。`i8*` `[N x i8]*` は警告
+   - **全部 `ptr` に統一**するのが正解
+
+3. **SSA 形式のラベル管理**
    - 各 basic block はただ一つの `ret` / `br` で終わる
    - 同じレジスタ名を 2 回代入しないよう、カウンタで連番を振る
 
-3. **printf の呼び出し**
-   - `printf` を `declare` しておかないとリンクエラー
-   - 第1引数は `i8*`、フォーマット文字列は global constant で確保
+4. **`printf` の宣言**
+   - `declare i32 @printf(ptr, ...)` を必ず置く
+   - 第 1 引数のフォーマット文字列は global constant として確保
+
+5. **`getelementptr` のインデックス**
+   - 配列要素へは `getelementptr <elem_ty>, ptr %base, i64 <index>`
+   - 構造体メンバへは `i32 N` でアクセス
+
+---
 
 ## Claude Code への指示例
 
@@ -123,16 +410,26 @@ exit:
 以下の仕様で、nb-lang の AST を LLVM IR に変換するコードジェネレータを
 {LANG} で実装してほしい。
 
-（上の IR サンプルをペースト）
-
 要件：
+- target triple は実行環境を検出して書き分ける（macOS arm64 / Linux x86-64）
+- opaque pointer (`ptr`) を使う（typed pointer は使わない）
+- Phase 1 → 2 → 3 と段階的に育てる
+- まず print(42); が通るところまで作って、それから変数・演算・制御構造を追加
 - CodeGen は可変長の文字列バッファ（StringBuilder 相当）で IR を組み立てる
 - %名前 の連番は counter で管理
 - basic block ラベルも counter で管理
 - 変数は alloca / load / store で扱う
-- まず print(42); が通るところまで作って、それから変数・演算・制御構造を追加
-- テストは llvm ir の文字列を assert する形式でもOK
+
+（このファイルの Phase 1 統合例 IR をペースト）
+
+ビルド検証：
+- 出力 IR を `out.ll` として保存
+- `clang out.ll -o a.out && ./a.out` で期待値が出ることを確認
+- macOS arm64 と Linux x86-64 で target triple を切り替えてビルドできるよう
+  CodeGen に環境検出ロジックを入れる
 ```
+
+---
 
 ## フォールバック戦略
 
@@ -153,3 +450,38 @@ int main() {
 - 既存の C のセマンティクスに丸乗りできる
 - 実装言語から文字列連結で生成
 - `clang example.c -o a.out`
+- ネイティブバイナリは出るので「ネイティブコンパイラ」の看板は守れる
+
+### プラン C：アセンブリ (.s) を吐いてリンカで処理
+
+LLVM IR への依存を避けたい場合、ターゲット環境のアセンブリを直接吐く方法もあります。
+
+```bash
+# 自作コンパイラが out.s を出力
+clang out.s -o a.out
+./a.out
+```
+
+- macOS arm64 と Linux x86-64 で **アセンブリの方言が完全に違う**
+  - macOS arm64: AArch64 アセンブリ（`bl`, `ret`, `mov` 等、Apple は独自ディレクティブ多め）
+  - Linux x86-64: x86-64 アセンブリ（AT&T 構文 or Intel 構文）
+- 環境ごとに別の CodeGen バックエンドが必要になる
+- **環境別の細かい差異は Claude Code / Codex に任せる**のが現実的（手書きで覚えるのは大変）
+- ABI（呼び出し規約・スタックフレーム・スタックアラインメント）も環境差あり
+- macOS arm64 では `_main` のように関数名にアンダースコア接頭辞が必要
+
+**Claude Code への指示例（プラン C）**：
+
+```text
+LLVM IR を経由せず、以下の環境向けのアセンブリを直接吐く CodeGen に
+書き換えてほしい。OS/アーキは uname で実行時に検出する。
+
+- macOS arm64: AArch64 アセンブリ（Apple の関数名規約を遵守）
+- Linux x86-64: x86-64 AT&T 構文アセンブリ
+
+最初は print(42); が `clang out.s -o a.out && ./a.out` で 42 を出す
+ところまで作る。それから変数・演算・制御フローを追加する。
+```
+
+- リンクは `clang` がリンカを呼び出してくれる（`ld` を直接叩かなくてOK）
+- 「ネイティブコンパイラ」感は **プラン B より強い**（実機械語に近い）が、移植性が下がる

--- a/cc-native-compiler-osaka-202605/prompts/language-spec.md
+++ b/cc-native-compiler-osaka-202605/prompts/language-spec.md
@@ -13,7 +13,7 @@
 **実装言語は以下の 3 つからお好きなものを選べます**（サポーターがフォローできる範囲）：
 
 - **Scala 3**（`scala-cli` / `sbt`）
-- **TypeScript**（Node.js 20+, `tsx` など）
+- **TypeScript**（[Bun](https://bun.sh/) 1.0+、`bun run main.ts` で直実行）
 - **Java**（17 以上）
 
 いずれの言語でも「AST を組み立てて LLVM IR を文字列で吐く」という骨子は同じです。
@@ -298,9 +298,9 @@ LLVM IR を文字列として吐き、clang でリンクしてネイティブバ
 まず Phase 1（整数演算 / 変数 / if / while / print）から実装する。
 
 要件：
-- Node.js 20+、tsx で実行
+- Bun 1.0+ で `bun run main.ts <source.nb>` で実行（TypeScript を直接走らせられる）
 - AST は discriminated union ({ kind: "..." } 形式) で表現
-- 外部ライブラリは使わない（Node 標準と組み込み型のみ）
+- 外部ライブラリは使わない（Bun 標準と組み込み型のみ）
 - LLVM IR は配列に push して join("\n") で組み立てる
 - target triple は process.platform で書き分ける
   （darwin → arm64-apple-macosx15.0.0、linux → x86_64-pc-linux-gnu）

--- a/cc-native-compiler-osaka-202605/prompts/language-spec.md
+++ b/cc-native-compiler-osaka-202605/prompts/language-spec.md
@@ -86,6 +86,31 @@ list-lit       = "[" ( expr ("," expr)* )? "]" ;
 - 関数定義は引数と戻り値の型注釈が必須
 - 型エラーはコンパイル時に検出する
 
+### 型推論ルール（簡易版）
+
+完全な型推論は重いので、以下の最小ルールで割り切る：
+
+1. **`val x = expr;`** — `expr` の型を見て `x` の型を決める
+2. **`var x = expr;`** — 同上、ただし以後の `x = expr2` は `x` の型と一致する `expr2` のみ許可
+3. **関数引数・戻り値** — 型注釈必須、推論しない
+4. **二項演算** — 両辺の型が一致する必要あり（`int + int → int`、`string + string` は今回サポート外）
+5. **比較演算** — `int` 同士、結果は `bool`（IR 上は `i1`）
+6. **リストリテラル `[a, b, c]`** — 全要素が同じ型 `T` で、結果は `list<T>`
+7. **インデックスアクセス `xs[i]`** — `xs: list<T>`, `i: int`、結果は `T`
+
+### 型エラーの例
+
+```
+val n = 10;
+val s = "hello";
+val bad = n + s;     // ← エラー：int + string は許されない
+
+var sum = 0;
+sum = "oops";        // ← エラー：var sum の型は int に固定された
+
+val xs = [1, 2, "three"];   // ← エラー：要素型が int / string で混在
+```
+
 ## 組み込み関数
 
 - `print(x)` — 値を標準出力に改行付きで出力
@@ -165,33 +190,259 @@ hello
 15
 ```
 
-## Claude Code への初期指示例
+## 3 言語別の完成プロンプト
 
-以下をそのまま貼って、段階的に育ててください。**{LANG}** の部分は選んだ実装言語に置き換えてください。
+選んだ実装言語の節の AST 設計例＋初期プロンプトをそのままコピペで Claude Code に渡せます。
 
+### Scala 3 版
+
+#### AST 設計例
+
+```scala
+enum Expr:
+  case IntLit(v: Long)
+  case StrLit(s: String)
+  case Var(name: String)
+  case BinOp(op: String, l: Expr, r: Expr)
+  case Call(name: String, args: List[Expr])
+  case Index(arr: Expr, idx: Expr)
+  case ListLit(elems: List[Expr])
+
+enum Stmt:
+  case ValDef(name: String, ty: Option[Type], init: Expr)
+  case VarDef(name: String, ty: Option[Type], init: Expr)
+  case Reassign(name: String, value: Expr)
+  case If(cond: Expr, thenBlk: List[Stmt], elseBlk: List[Stmt])
+  case While(cond: Expr, body: List[Stmt])
+  case Print(value: Expr)
+  case Return(value: Expr)
+  case ExprStmt(value: Expr)
+
+case class FunDef(
+  name: String, params: List[(String, Type)],
+  retType: Type, body: List[Stmt]
+)
+
+enum Type:
+  case TInt, TString
+  case TList(elem: Type)
 ```
-{LANG} で、小さな言語 "nb-lang" のネイティブコンパイラを実装したい。
-LLVM IR を文字列として吐き、clang でリンクしてネイティブバイナリを作る方針で進める。
 
-まずは以下の仕様の Phase 1 部分を実装してほしい：
-- 整数演算 / 変数 / if / while / print
-- 出力は LLVM IR のテキスト
+#### 初期プロンプト
 
-（言語仕様 Phase 1 部分をペースト）
+```text
+Scala 3 で、小さな言語 "nb-lang" のネイティブコンパイラを実装したい。
+LLVM IR を文字列として吐き、clang でリンクしてネイティブバイナリを作る方針。
 
-方針：
-- ファイル分割は Main / Lexer / Parser / Ast / TypeCheck / CodeGen の 6 本構成
-- 外部ライブラリは使わない（標準ライブラリのみ）
-- LLVM IR は文字列として書き出す
-- まず Lexer と Parser を作り、動くことを確認してから CodeGen に進む
-- Phase 1 が通ったら、段階的に Phase 2 (関数), Phase 3 (文字列/リスト/型) を追加
+まず Phase 1（整数演算 / 変数 / if / while / print）から実装する。
+
+要件：
+- scala-cli プロジェクトで 5〜6 本（Main / Lexer / Parser / Ast / TypeCheck / CodeGen）
+- AST は enum + case class で表現
+- 外部ライブラリは使わない（Scala 標準のみ）
+- LLVM IR は StringBuilder で組み立てる
+- target triple は実行環境を検出して書き分ける（macOS arm64 / Linux x86-64）
+
+最初のゴール：
+- examples/sum.nb（1〜10 の和）をコンパイルして out.ll を生成、
+  clang out.ll -o a.out && ./a.out で 55 が出ること
+
+（language-spec.md の Phase 1 部分と backend-strategy.md の Phase 1 統合例 IR をペースト）
 ```
 
-### 言語別の補足
+---
 
-- **Scala 3**：`scala-cli` で 1 ディレクトリ実行。AST は `enum` / `sealed trait` + `case class`
-- **TypeScript**：`node --loader ts-node/esm` か `tsx` で実行。AST は `type` union + discriminated union
-- **Java**：Java 17+ の `record` + `sealed interface` で AST を表現すると楽
+### TypeScript 版
+
+#### AST 設計例
+
+```typescript
+type Expr =
+  | { kind: "IntLit"; value: number }
+  | { kind: "StrLit"; value: string }
+  | { kind: "Var"; name: string }
+  | { kind: "BinOp"; op: string; left: Expr; right: Expr }
+  | { kind: "Call"; name: string; args: Expr[] }
+  | { kind: "Index"; arr: Expr; idx: Expr }
+  | { kind: "ListLit"; elems: Expr[] };
+
+type Stmt =
+  | { kind: "ValDef"; name: string; ty?: Type; init: Expr }
+  | { kind: "VarDef"; name: string; ty?: Type; init: Expr }
+  | { kind: "Reassign"; name: string; value: Expr }
+  | { kind: "If"; cond: Expr; thenBlk: Stmt[]; elseBlk: Stmt[] }
+  | { kind: "While"; cond: Expr; body: Stmt[] }
+  | { kind: "Print"; value: Expr }
+  | { kind: "Return"; value: Expr }
+  | { kind: "ExprStmt"; value: Expr };
+
+type FunDef = {
+  name: string;
+  params: [string, Type][];
+  retType: Type;
+  body: Stmt[];
+};
+
+type Type =
+  | { kind: "TInt" }
+  | { kind: "TString" }
+  | { kind: "TList"; elem: Type };
+```
+
+#### 初期プロンプト
+
+```text
+TypeScript で、小さな言語 "nb-lang" のネイティブコンパイラを実装したい。
+LLVM IR を文字列として吐き、clang でリンクしてネイティブバイナリを作る方針。
+
+まず Phase 1（整数演算 / 変数 / if / while / print）から実装する。
+
+要件：
+- Node.js 20+、tsx で実行
+- AST は discriminated union ({ kind: "..." } 形式) で表現
+- 外部ライブラリは使わない（Node 標準と組み込み型のみ）
+- LLVM IR は配列に push して join("\n") で組み立てる
+- target triple は process.platform で書き分ける
+  （darwin → arm64-apple-macosx15.0.0、linux → x86_64-pc-linux-gnu）
+
+最初のゴール：
+- examples/sum.nb をコンパイルして out.ll を生成、
+  clang out.ll -o a.out && ./a.out で 55 が出ること
+
+（language-spec.md の Phase 1 部分と backend-strategy.md の Phase 1 統合例 IR をペースト）
+```
+
+---
+
+### Java 版
+
+#### AST 設計例
+
+```java
+sealed interface Expr permits IntLit, StrLit, Var, BinOp, Call, Index, ListLit {}
+record IntLit(long value)                              implements Expr {}
+record StrLit(String value)                            implements Expr {}
+record Var(String name)                                implements Expr {}
+record BinOp(String op, Expr left, Expr right)         implements Expr {}
+record Call(String name, java.util.List<Expr> args)    implements Expr {}
+record Index(Expr arr, Expr idx)                       implements Expr {}
+record ListLit(java.util.List<Expr> elems)             implements Expr {}
+
+sealed interface Stmt permits ValDef, VarDef, Reassign, If, While, Print, Return, ExprStmt {}
+record ValDef(String name, Type ty, Expr init)         implements Stmt {}
+record VarDef(String name, Type ty, Expr init)         implements Stmt {}
+record Reassign(String name, Expr value)               implements Stmt {}
+record If(Expr cond, java.util.List<Stmt> thenBlk,
+          java.util.List<Stmt> elseBlk)                implements Stmt {}
+record While(Expr cond, java.util.List<Stmt> body)     implements Stmt {}
+record Print(Expr value)                               implements Stmt {}
+record Return(Expr value)                              implements Stmt {}
+record ExprStmt(Expr value)                            implements Stmt {}
+
+record FunDef(String name, java.util.List<Param> params,
+              Type retType, java.util.List<Stmt> body) {}
+record Param(String name, Type ty) {}
+
+sealed interface Type permits TInt, TString, TList {}
+record TInt()                  implements Type {}
+record TString()               implements Type {}
+record TList(Type elem)        implements Type {}
+```
+
+#### 初期プロンプト
+
+```text
+Java で、小さな言語 "nb-lang" のネイティブコンパイラを実装したい。
+LLVM IR を文字列として吐き、clang でリンクしてネイティブバイナリを作る方針。
+
+まず Phase 1（整数演算 / 変数 / if / while / print）から実装する。
+
+要件：
+- Java 17 以上、java Main.java で単一ファイル実行 or javac でビルド
+- AST は sealed interface + record で表現（パターンマッチで分岐できる）
+- 外部ライブラリは使わない（JDK 標準のみ）
+- LLVM IR は StringBuilder で組み立てる
+- target triple は System.getProperty("os.name") で書き分ける
+
+最初のゴール：
+- examples/sum.nb をコンパイルして out.ll を生成、
+  clang out.ll -o a.out && ./a.out で 55 が出ること
+
+（language-spec.md の Phase 1 部分と backend-strategy.md の Phase 1 統合例 IR をペースト）
+```
+
+---
+
+## バックエンド方針の選択肢
+
+`backend-strategy.md` で 3 プラン（A: LLVM IR / B: C / C: アセンブリ .s）を解説。
+**最初は A（LLVM IR）**を推奨、詰まったら B（C 経由）に切り替え。
+プラン C（.s 直書き）は環境差が大きいので、Claude Code / Codex に任せる前提で挑戦するなら可。
+
+---
+
+## 詰まった時の対話プロンプト集
+
+ハンズオン中に Claude Code が脱線・混乱した時のリカバリ用。状況に合わせて選んでください。
+
+### Lexer/Parser でエラーが出る
+
+```text
+今のコードで以下の入力を食わせるとエラーになる：
+
+(エラー出力をペースト)
+
+入力ソース：
+(問題のある .nb ファイルの中身をペースト)
+
+期待される動作：
+(期待する AST 構造、または「このトークン列に分解されてほしい」を簡潔に書く)
+
+該当箇所のコードを直してほしい。
+```
+
+### CodeGen の出力 IR が clang で警告/エラーになる
+
+```text
+出力された IR を clang でビルドすると以下が出る：
+
+(clang の出力をペースト)
+
+出力 IR：
+(out.ll の中身をペースト)
+
+backend-strategy.md の動作検証済みサンプルと比べて、どこが違うか
+特定して修正してほしい。
+```
+
+### 一気に書きすぎて全体把握できなくなった
+
+```text
+今のディレクトリ構成と各ファイルの役割を 1 行ずつ要約してほしい。
+それから、Phase 1 の最小機能（print(42); だけが動く）に立ち返って、
+そこから動作確認しながら段階的に機能を追加する流れに整理し直したい。
+```
+
+### Phase 2/3 への拡張で AST がぐちゃぐちゃになった
+
+```text
+今の AST 定義を見直して、以下の Phase 1〜3 の構文を全部表現できる
+最小の AST に整理し直してほしい。書き直しでもいい。
+
+(language-spec.md の構文定義をペースト)
+```
+
+### バックエンドを LLVM IR から C 経由に切り替えたい
+
+```text
+LLVM IR が手に負えなくなってきたので、CodeGen を C 出力に切り替えたい。
+backend-strategy.md の「プラン B」の方針で書き直してほしい。
+- 出力は example.c
+- ビルドは clang example.c -o a.out
+- ランタイムは標準 C ライブラリの printf / malloc のみ使う
+
+AST 構造はそのまま、CodeGen だけ差し替えてほしい。
+```
 
 ## 補足：Claude Code との付き合い方
 

--- a/cc-native-compiler-osaka-202605/src/java/Main.java
+++ b/cc-native-compiler-osaka-202605/src/java/Main.java
@@ -1,13 +1,389 @@
-// nb-lang compiler — Java skeleton
-// 実行例: java Main.java <source.nb>
-// ハンズオン中に Claude Code と一緒に埋めていきます。
+// nb-lang compiler — Java reference implementation (Phase 1)
+// 実行: java Main.java <source.nb>
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class Main {
-    public static void main(String[] args) {
-        if (args.length == 0) {
-            System.out.println("usage: java Main.java <source.nb>");
-        } else {
-            System.out.println("TODO: compile " + args[0]);
+
+    // ===== AST =====
+
+    sealed interface Expr permits IntLit, Var, BinOp {}
+    record IntLit(long value)                            implements Expr {}
+    record Var(String name)                              implements Expr {}
+    record BinOp(String op, Expr left, Expr right)       implements Expr {}
+
+    sealed interface Stmt permits ValDef, VarDef, Reassign, If, While, Print {}
+    record ValDef(String name, Expr init)                implements Stmt {}
+    record VarDef(String name, Expr init)                implements Stmt {}
+    record Reassign(String name, Expr value)             implements Stmt {}
+    record If(Expr cond, List<Stmt> thenBlk, List<Stmt> elseBlk) implements Stmt {}
+    record While(Expr cond, List<Stmt> body)             implements Stmt {}
+    record Print(Expr value)                             implements Stmt {}
+
+    // ===== Token =====
+
+    sealed interface Token permits IntT, Ident, Kw, Op, LParen, RParen, LBrace, RBrace, Semi, EOF {}
+    record IntT(long value)        implements Token {}
+    record Ident(String name)      implements Token {}
+    record Kw(String name)         implements Token {}
+    record Op(String value)        implements Token {}
+    record LParen()                implements Token {}
+    record RParen()                implements Token {}
+    record LBrace()                implements Token {}
+    record RBrace()                implements Token {}
+    record Semi()                  implements Token {}
+    record EOF()                   implements Token {}
+
+    // ===== Lexer =====
+
+    static final Set<String> KEYWORDS = Set.of("val", "var", "if", "else", "while", "print");
+
+    static List<Token> tokenize(String src) {
+        List<Token> tokens = new ArrayList<>();
+        int i = 0, n = src.length();
+
+        while (i < n) {
+            char c = src.charAt(i);
+            if (Character.isWhitespace(c)) { i++; continue; }
+            if (c == '/' && i + 1 < n && src.charAt(i + 1) == '/') {
+                while (i < n && src.charAt(i) != '\n') i++;
+                continue;
+            }
+            if (Character.isDigit(c)) {
+                int j = i;
+                while (j < n && Character.isDigit(src.charAt(j))) j++;
+                tokens.add(new IntT(Long.parseLong(src.substring(i, j))));
+                i = j;
+                continue;
+            }
+            if (Character.isLetter(c) || c == '_') {
+                int j = i;
+                while (j < n && (Character.isLetterOrDigit(src.charAt(j)) || src.charAt(j) == '_')) j++;
+                String word = src.substring(i, j);
+                tokens.add(KEYWORDS.contains(word) ? new Kw(word) : new Ident(word));
+                i = j;
+                continue;
+            }
+            if (c == '(') { tokens.add(new LParen()); i++; continue; }
+            if (c == ')') { tokens.add(new RParen()); i++; continue; }
+            if (c == '{') { tokens.add(new LBrace()); i++; continue; }
+            if (c == '}') { tokens.add(new RBrace()); i++; continue; }
+            if (c == ';') { tokens.add(new Semi());   i++; continue; }
+            if (c == '=' && i + 1 < n && src.charAt(i + 1) == '=') { tokens.add(new Op("==")); i += 2; continue; }
+            if (c == '!' && i + 1 < n && src.charAt(i + 1) == '=') { tokens.add(new Op("!=")); i += 2; continue; }
+            if (c == '<' && i + 1 < n && src.charAt(i + 1) == '=') { tokens.add(new Op("<=")); i += 2; continue; }
+            if (c == '>' && i + 1 < n && src.charAt(i + 1) == '=') { tokens.add(new Op(">=")); i += 2; continue; }
+            if ("+-*/%<>=".indexOf(c) >= 0) { tokens.add(new Op(String.valueOf(c))); i++; continue; }
+            throw new RuntimeException("Unknown char: '" + c + "' at " + i);
         }
+        tokens.add(new EOF());
+        return tokens;
+    }
+
+    // ===== Parser =====
+
+    static class Parser {
+        private final List<Token> tokens;
+        private int pos = 0;
+
+        Parser(List<Token> tokens) { this.tokens = tokens; }
+
+        private Token peek() { return tokens.get(pos); }
+        private Token consume() { return tokens.get(pos++); }
+
+        List<Stmt> parseProgram() {
+            List<Stmt> stmts = new ArrayList<>();
+            while (!(peek() instanceof EOF)) stmts.add(parseStmt());
+            return stmts;
+        }
+
+        private Stmt parseStmt() {
+            Token t = peek();
+            if (t instanceof Kw kw) {
+                return switch (kw.name()) {
+                    case "val"   -> parseValDef();
+                    case "var"   -> parseVarDef();
+                    case "if"    -> parseIf();
+                    case "while" -> parseWhile();
+                    case "print" -> parsePrint();
+                    default      -> throw new RuntimeException("Unexpected keyword: " + kw.name());
+                };
+            }
+            if (t instanceof Ident) return parseReassign();
+            throw new RuntimeException("Unexpected token: " + t);
+        }
+
+        private Stmt parseValDef() {
+            consume(); // val
+            String name = consumeIdent();
+            expectOp("=");
+            Expr init = parseExpr();
+            expectSemi();
+            return new ValDef(name, init);
+        }
+
+        private Stmt parseVarDef() {
+            consume(); // var
+            String name = consumeIdent();
+            expectOp("=");
+            Expr init = parseExpr();
+            expectSemi();
+            return new VarDef(name, init);
+        }
+
+        private Stmt parseReassign() {
+            String name = consumeIdent();
+            expectOp("=");
+            Expr value = parseExpr();
+            expectSemi();
+            return new Reassign(name, value);
+        }
+
+        private Stmt parseIf() {
+            consume(); // if
+            expect(LParen.class);
+            Expr cond = parseExpr();
+            expect(RParen.class);
+            List<Stmt> thenBlk = parseBlock();
+            List<Stmt> elseBlk = new ArrayList<>();
+            if (peek() instanceof Kw kw && kw.name().equals("else")) {
+                consume();
+                elseBlk = parseBlock();
+            }
+            return new If(cond, thenBlk, elseBlk);
+        }
+
+        private Stmt parseWhile() {
+            consume(); // while
+            expect(LParen.class);
+            Expr cond = parseExpr();
+            expect(RParen.class);
+            List<Stmt> body = parseBlock();
+            return new While(cond, body);
+        }
+
+        private Stmt parsePrint() {
+            consume(); // print
+            expect(LParen.class);
+            Expr v = parseExpr();
+            expect(RParen.class);
+            expectSemi();
+            return new Print(v);
+        }
+
+        private List<Stmt> parseBlock() {
+            expect(LBrace.class);
+            List<Stmt> stmts = new ArrayList<>();
+            while (!(peek() instanceof RBrace)) stmts.add(parseStmt());
+            consume(); // }
+            return stmts;
+        }
+
+        private Expr parseExpr() { return parseComparison(); }
+
+        private Expr parseComparison() {
+            Expr left = parseAdditive();
+            while (isOp(Set.of("==", "!=", "<", "<=", ">", ">="))) {
+                String op = ((Op) consume()).value();
+                Expr right = parseAdditive();
+                left = new BinOp(op, left, right);
+            }
+            return left;
+        }
+
+        private Expr parseAdditive() {
+            Expr left = parseMultiplicative();
+            while (isOp(Set.of("+", "-"))) {
+                String op = ((Op) consume()).value();
+                Expr right = parseMultiplicative();
+                left = new BinOp(op, left, right);
+            }
+            return left;
+        }
+
+        private Expr parseMultiplicative() {
+            Expr left = parsePrimary();
+            while (isOp(Set.of("*", "/", "%"))) {
+                String op = ((Op) consume()).value();
+                Expr right = parsePrimary();
+                left = new BinOp(op, left, right);
+            }
+            return left;
+        }
+
+        private Expr parsePrimary() {
+            Token t = consume();
+            if (t instanceof IntT it) return new IntLit(it.value());
+            if (t instanceof Ident id) return new Var(id.name());
+            if (t instanceof LParen) {
+                Expr e = parseExpr();
+                expect(RParen.class);
+                return e;
+            }
+            throw new RuntimeException("Expected primary, got " + t);
+        }
+
+        private boolean isOp(Set<String> ops) {
+            return peek() instanceof Op op && ops.contains(op.value());
+        }
+
+        private String consumeIdent() {
+            Token t = consume();
+            if (!(t instanceof Ident id)) throw new RuntimeException("Expected ident, got " + t);
+            return id.name();
+        }
+
+        private void expectOp(String value) {
+            Token t = consume();
+            if (!(t instanceof Op op) || !op.value().equals(value)) {
+                throw new RuntimeException("Expected '" + value + "', got " + t);
+            }
+        }
+
+        private void expect(Class<? extends Token> kind) {
+            Token t = consume();
+            if (!kind.isInstance(t)) {
+                throw new RuntimeException("Expected " + kind.getSimpleName() + ", got " + t);
+            }
+        }
+
+        private void expectSemi() { expect(Semi.class); }
+    }
+
+    // ===== CodeGen =====
+
+    static class CodeGen {
+        private final StringBuilder sb = new StringBuilder();
+        private int tempCounter = 0;
+        private int labelCounter = 0;
+
+        private String fresh() {
+            tempCounter++;
+            return "%t" + tempCounter;
+        }
+
+        private String freshLabel(String prefix) {
+            labelCounter++;
+            return prefix + labelCounter;
+        }
+
+        private void emit(String line) { sb.append(line).append('\n'); }
+
+        private String detectTriple() {
+            String os = System.getProperty("os.name").toLowerCase();
+            return os.contains("mac") ? "arm64-apple-macosx15.0.0" : "x86_64-pc-linux-gnu";
+        }
+
+        String gen(List<Stmt> program) {
+            emit("; ModuleID = 'nb-lang'");
+            emit("target triple = \"" + detectTriple() + "\"");
+            emit("");
+            emit("@fmt = private constant [5 x i8] c\"%ld\\0A\\00\"");
+            emit("declare i32 @printf(ptr, ...)");
+            emit("");
+            emit("define i32 @main() {");
+            emit("entry:");
+            for (Stmt s : program) genStmt(s);
+            emit("  ret i32 0");
+            emit("}");
+            return sb.toString();
+        }
+
+        private void genStmt(Stmt s) {
+            if (s instanceof ValDef d) {
+                emit("  %" + d.name() + " = alloca i64, align 8");
+                String v = genExpr(d.init());
+                emit("  store i64 " + v + ", ptr %" + d.name());
+            } else if (s instanceof VarDef d) {
+                emit("  %" + d.name() + " = alloca i64, align 8");
+                String v = genExpr(d.init());
+                emit("  store i64 " + v + ", ptr %" + d.name());
+            } else if (s instanceof Reassign r) {
+                String v = genExpr(r.value());
+                emit("  store i64 " + v + ", ptr %" + r.name());
+            } else if (s instanceof Print p) {
+                String v = genExpr(p.value());
+                emit("  call i32 (ptr, ...) @printf(ptr @fmt, i64 " + v + ")");
+            } else if (s instanceof If i) {
+                String c = genExpr(i.cond());
+                String ci1 = fresh();
+                emit("  " + ci1 + " = icmp ne i64 " + c + ", 0");
+                String thenL = freshLabel("then");
+                String elseL = freshLabel("else");
+                String endL  = freshLabel("ifend");
+                emit("  br i1 " + ci1 + ", label %" + thenL + ", label %" + elseL);
+                emit(thenL + ":");
+                for (Stmt st : i.thenBlk()) genStmt(st);
+                emit("  br label %" + endL);
+                emit(elseL + ":");
+                for (Stmt st : i.elseBlk()) genStmt(st);
+                emit("  br label %" + endL);
+                emit(endL + ":");
+            } else if (s instanceof While w) {
+                String condL = freshLabel("cond");
+                String bodyL = freshLabel("body");
+                String exitL = freshLabel("exit");
+                emit("  br label %" + condL);
+                emit(condL + ":");
+                String c = genExpr(w.cond());
+                String ci1 = fresh();
+                emit("  " + ci1 + " = icmp ne i64 " + c + ", 0");
+                emit("  br i1 " + ci1 + ", label %" + bodyL + ", label %" + exitL);
+                emit(bodyL + ":");
+                for (Stmt st : w.body()) genStmt(st);
+                emit("  br label %" + condL);
+                emit(exitL + ":");
+            }
+        }
+
+        private String genExpr(Expr e) {
+            if (e instanceof IntLit il) return Long.toString(il.value());
+            if (e instanceof Var v) {
+                String r = fresh();
+                emit("  " + r + " = load i64, ptr %" + v.name());
+                return r;
+            }
+            if (e instanceof BinOp b) {
+                String lv = genExpr(b.left());
+                String rv = genExpr(b.right());
+                String res = fresh();
+                Map<String, String> arith = Map.of(
+                    "+", "add", "-", "sub", "*", "mul", "/", "sdiv", "%", "srem"
+                );
+                Map<String, String> cmp = Map.of(
+                    "==", "eq", "!=", "ne", "<", "slt", "<=", "sle", ">", "sgt", ">=", "sge"
+                );
+                if (arith.containsKey(b.op())) {
+                    emit("  " + res + " = " + arith.get(b.op()) + " i64 " + lv + ", " + rv);
+                } else if (cmp.containsKey(b.op())) {
+                    String tmp = fresh();
+                    emit("  " + tmp + " = icmp " + cmp.get(b.op()) + " i64 " + lv + ", " + rv);
+                    emit("  " + res + " = zext i1 " + tmp + " to i64");
+                } else {
+                    throw new RuntimeException("Unknown op: " + b.op());
+                }
+                return res;
+            }
+            throw new RuntimeException("Unknown expr: " + e);
+        }
+    }
+
+    // ===== Main =====
+
+    public static void main(String[] args) throws Exception {
+        if (args.length == 0) {
+            System.err.println("usage: java Main.java <source.nb>");
+            System.exit(1);
+        }
+        String src = Files.readString(Path.of(args[0]));
+        List<Token> tokens = tokenize(src);
+        List<Stmt> program = new Parser(tokens).parseProgram();
+        String ir = new CodeGen().gen(program);
+        System.out.print(ir);
     }
 }

--- a/cc-native-compiler-osaka-202605/src/scala3/Ast.scala
+++ b/cc-native-compiler-osaka-202605/src/scala3/Ast.scala
@@ -1,0 +1,14 @@
+package nblang
+
+enum Expr:
+  case IntLit(v: Long)
+  case Var(name: String)
+  case BinOp(op: String, l: Expr, r: Expr)
+
+enum Stmt:
+  case ValDef(name: String, init: Expr)
+  case VarDef(name: String, init: Expr)
+  case Reassign(name: String, value: Expr)
+  case If(cond: Expr, thenBlk: List[Stmt], elseBlk: List[Stmt])
+  case While(cond: Expr, body: List[Stmt])
+  case Print(value: Expr)

--- a/cc-native-compiler-osaka-202605/src/scala3/CodeGen.scala
+++ b/cc-native-compiler-osaka-202605/src/scala3/CodeGen.scala
@@ -1,0 +1,120 @@
+package nblang
+
+class CodeGen:
+  private val sb = StringBuilder()
+  private var tempCounter = 0
+  private var labelCounter = 0
+
+  private def fresh(): String =
+    tempCounter += 1
+    s"%t$tempCounter"
+
+  private def freshLabel(prefix: String): String =
+    labelCounter += 1
+    s"$prefix$labelCounter"
+
+  private def emit(line: String): Unit =
+    sb.append(line).append('\n')
+
+  private def detectTriple: String =
+    val os = System.getProperty("os.name").toLowerCase
+    if os.contains("mac") then "arm64-apple-macosx15.0.0"
+    else "x86_64-pc-linux-gnu"
+
+  def gen(program: List[Stmt]): String =
+    emit("; ModuleID = 'nb-lang'")
+    emit(s"""target triple = "$detectTriple"""")
+    emit("")
+    emit("@fmt = private constant [5 x i8] c\"%ld\\0A\\00\"")
+    emit("declare i32 @printf(ptr, ...)")
+    emit("")
+    emit("define i32 @main() {")
+    emit("entry:")
+
+    program.foreach(genStmt)
+
+    emit("  ret i32 0")
+    emit("}")
+    sb.toString
+
+  private def genStmt(stmt: Stmt): Unit = stmt match
+    case Stmt.ValDef(name, init) =>
+      emit(s"  %$name = alloca i64, align 8")
+      val v = genExpr(init)
+      emit(s"  store i64 $v, ptr %$name")
+
+    case Stmt.VarDef(name, init) =>
+      emit(s"  %$name = alloca i64, align 8")
+      val v = genExpr(init)
+      emit(s"  store i64 $v, ptr %$name")
+
+    case Stmt.Reassign(name, value) =>
+      val v = genExpr(value)
+      emit(s"  store i64 $v, ptr %$name")
+
+    case Stmt.Print(value) =>
+      val v = genExpr(value)
+      emit(s"  call i32 (ptr, ...) @printf(ptr @fmt, i64 $v)")
+
+    case Stmt.If(cond, thenBlk, elseBlk) =>
+      val c = genExpr(cond)
+      val ci1 = fresh()
+      emit(s"  $ci1 = icmp ne i64 $c, 0")
+      val thenL = freshLabel("then")
+      val elseL = freshLabel("else")
+      val endL  = freshLabel("ifend")
+      emit(s"  br i1 $ci1, label %$thenL, label %$elseL")
+      emit(s"$thenL:")
+      thenBlk.foreach(genStmt)
+      emit(s"  br label %$endL")
+      emit(s"$elseL:")
+      elseBlk.foreach(genStmt)
+      emit(s"  br label %$endL")
+      emit(s"$endL:")
+
+    case Stmt.While(cond, body) =>
+      val condL = freshLabel("cond")
+      val bodyL = freshLabel("body")
+      val exitL = freshLabel("exit")
+      emit(s"  br label %$condL")
+      emit(s"$condL:")
+      val c   = genExpr(cond)
+      val ci1 = fresh()
+      emit(s"  $ci1 = icmp ne i64 $c, 0")
+      emit(s"  br i1 $ci1, label %$bodyL, label %$exitL")
+      emit(s"$bodyL:")
+      body.foreach(genStmt)
+      emit(s"  br label %$condL")
+      emit(s"$exitL:")
+
+  private def genExpr(expr: Expr): String = expr match
+    case Expr.IntLit(v) => v.toString
+
+    case Expr.Var(name) =>
+      val r = fresh()
+      emit(s"  $r = load i64, ptr %$name")
+      r
+
+    case Expr.BinOp(op, l, r) =>
+      val lv  = genExpr(l)
+      val rv  = genExpr(r)
+      val res = fresh()
+      op match
+        case "+"  => emit(s"  $res = add i64 $lv, $rv")
+        case "-"  => emit(s"  $res = sub i64 $lv, $rv")
+        case "*"  => emit(s"  $res = mul i64 $lv, $rv")
+        case "/"  => emit(s"  $res = sdiv i64 $lv, $rv")
+        case "%"  => emit(s"  $res = srem i64 $lv, $rv")
+        case "==" => cmpToInt(res, "eq",  lv, rv)
+        case "!=" => cmpToInt(res, "ne",  lv, rv)
+        case "<"  => cmpToInt(res, "slt", lv, rv)
+        case "<=" => cmpToInt(res, "sle", lv, rv)
+        case ">"  => cmpToInt(res, "sgt", lv, rv)
+        case ">=" => cmpToInt(res, "sge", lv, rv)
+        case _    => throw new RuntimeException(s"Unknown op: $op")
+      res
+
+  private def cmpToInt(res: String, pred: String, lv: String, rv: String): Unit =
+    val tmp = fresh()
+    emit(s"  $tmp = icmp $pred i64 $lv, $rv")
+    emit(s"  $res = zext i1 $tmp to i64")

--- a/cc-native-compiler-osaka-202605/src/scala3/Lexer.scala
+++ b/cc-native-compiler-osaka-202605/src/scala3/Lexer.scala
@@ -1,0 +1,56 @@
+package nblang
+
+enum Token:
+  case IntT(v: Long)
+  case Ident(s: String)
+  case KwVal, KwVar, KwIf, KwElse, KwWhile, KwPrint
+  case Op(s: String)
+  case LParen, RParen, LBrace, RBrace, Semi, EOF
+
+object Lexer:
+  def tokenize(src: String): List[Token] =
+    val buf = scala.collection.mutable.ListBuffer[Token]()
+    var i = 0
+    val n = src.length
+
+    while i < n do
+      val c = src(i)
+      if c.isWhitespace then
+        i += 1
+      else if c == '/' && i + 1 < n && src(i + 1) == '/' then
+        while i < n && src(i) != '\n' do i += 1
+      else if c.isDigit then
+        var j = i
+        while j < n && src(j).isDigit do j += 1
+        buf += Token.IntT(src.substring(i, j).toLong)
+        i = j
+      else if c.isLetter || c == '_' then
+        var j = i
+        while j < n && (src(j).isLetterOrDigit || src(j) == '_') do j += 1
+        val word = src.substring(i, j)
+        buf += (word match
+          case "val"   => Token.KwVal
+          case "var"   => Token.KwVar
+          case "if"    => Token.KwIf
+          case "else"  => Token.KwElse
+          case "while" => Token.KwWhile
+          case "print" => Token.KwPrint
+          case _       => Token.Ident(word))
+        i = j
+      else if c == '(' then { buf += Token.LParen; i += 1 }
+      else if c == ')' then { buf += Token.RParen; i += 1 }
+      else if c == '{' then { buf += Token.LBrace; i += 1 }
+      else if c == '}' then { buf += Token.RBrace; i += 1 }
+      else if c == ';' then { buf += Token.Semi;   i += 1 }
+      else if c == '=' && i + 1 < n && src(i + 1) == '=' then { buf += Token.Op("=="); i += 2 }
+      else if c == '!' && i + 1 < n && src(i + 1) == '=' then { buf += Token.Op("!="); i += 2 }
+      else if c == '<' && i + 1 < n && src(i + 1) == '=' then { buf += Token.Op("<="); i += 2 }
+      else if c == '>' && i + 1 < n && src(i + 1) == '=' then { buf += Token.Op(">="); i += 2 }
+      else if c == '<' then { buf += Token.Op("<");  i += 1 }
+      else if c == '>' then { buf += Token.Op(">");  i += 1 }
+      else if c == '=' then { buf += Token.Op("=");  i += 1 }
+      else if "+-*/%".contains(c) then { buf += Token.Op(c.toString); i += 1 }
+      else throw new RuntimeException(s"Unknown char: '$c' at position $i")
+
+    buf += Token.EOF
+    buf.toList

--- a/cc-native-compiler-osaka-202605/src/scala3/Main.scala
+++ b/cc-native-compiler-osaka-202605/src/scala3/Main.scala
@@ -1,11 +1,18 @@
 //> using scala 3.5
 //> using jvm 21
 
-// nb-lang compiler — skeleton
-// ハンズオン中に Claude Code と一緒に埋めていきます。
+package nblang
 
-@main def main(args: String*): Unit =
+import scala.io.Source
+
+@main def nbLangCompile(args: String*): Unit =
   if args.isEmpty then
-    println("usage: scala-cli run src/main -- <source.nb>")
-  else
-    println(s"TODO: compile ${args.head}")
+    Console.err.println("usage: scala-cli run . -- <source.nb>")
+    sys.exit(1)
+  val src     = Source.fromFile(args.head).mkString
+  val tokens  = Lexer.tokenize(src)
+  val parser  = new Parser(tokens)
+  val program = parser.parseProgram()
+  val codegen = new CodeGen()
+  val ir      = codegen.gen(program)
+  print(ir)

--- a/cc-native-compiler-osaka-202605/src/scala3/Parser.scala
+++ b/cc-native-compiler-osaka-202605/src/scala3/Parser.scala
@@ -1,0 +1,150 @@
+package nblang
+
+class Parser(tokens: List[Token]):
+  private var pos = 0
+
+  private def peek: Token = tokens(pos)
+
+  private def consume(): Token =
+    val t = tokens(pos)
+    pos += 1
+    t
+
+  private def expect(t: Token): Token =
+    val cur = consume()
+    if cur != t then
+      throw new RuntimeException(s"Expected $t but got $cur at position ${pos - 1}")
+    cur
+
+  def parseProgram(): List[Stmt] =
+    val stmts = scala.collection.mutable.ListBuffer[Stmt]()
+    while peek != Token.EOF do
+      stmts += parseStmt()
+    stmts.toList
+
+  private def parseStmt(): Stmt =
+    peek match
+      case Token.KwVal    => parseValDef()
+      case Token.KwVar    => parseVarDef()
+      case Token.KwIf     => parseIf()
+      case Token.KwWhile  => parseWhile()
+      case Token.KwPrint  => parsePrint()
+      case Token.Ident(_) => parseReassign()
+      case t              => throw new RuntimeException(s"Unexpected token: $t")
+
+  private def parseValDef(): Stmt =
+    expect(Token.KwVal)
+    val name = consumeIdent()
+    expect(Token.Op("="))
+    val init = parseExpr()
+    expect(Token.Semi)
+    Stmt.ValDef(name, init)
+
+  private def parseVarDef(): Stmt =
+    expect(Token.KwVar)
+    val name = consumeIdent()
+    expect(Token.Op("="))
+    val init = parseExpr()
+    expect(Token.Semi)
+    Stmt.VarDef(name, init)
+
+  private def parseReassign(): Stmt =
+    val name = consumeIdent()
+    expect(Token.Op("="))
+    val value = parseExpr()
+    expect(Token.Semi)
+    Stmt.Reassign(name, value)
+
+  private def parseIf(): Stmt =
+    expect(Token.KwIf)
+    expect(Token.LParen)
+    val cond = parseExpr()
+    expect(Token.RParen)
+    val thenBlk = parseBlock()
+    val elseBlk =
+      if peek == Token.KwElse then
+        consume()
+        parseBlock()
+      else List()
+    Stmt.If(cond, thenBlk, elseBlk)
+
+  private def parseWhile(): Stmt =
+    expect(Token.KwWhile)
+    expect(Token.LParen)
+    val cond = parseExpr()
+    expect(Token.RParen)
+    val body = parseBlock()
+    Stmt.While(cond, body)
+
+  private def parsePrint(): Stmt =
+    expect(Token.KwPrint)
+    expect(Token.LParen)
+    val v = parseExpr()
+    expect(Token.RParen)
+    expect(Token.Semi)
+    Stmt.Print(v)
+
+  private def parseBlock(): List[Stmt] =
+    expect(Token.LBrace)
+    val stmts = scala.collection.mutable.ListBuffer[Stmt]()
+    while peek != Token.RBrace do
+      stmts += parseStmt()
+    expect(Token.RBrace)
+    stmts.toList
+
+  // expr = comparison
+  private def parseExpr(): Expr = parseComparison()
+
+  private def parseComparison(): Expr =
+    var left = parseAdditive()
+    while isCmpOp(peek) do
+      val op = peek.asInstanceOf[Token.Op].s
+      consume()
+      val right = parseAdditive()
+      left = Expr.BinOp(op, left, right)
+    left
+
+  private def parseAdditive(): Expr =
+    var left = parseMultiplicative()
+    while isAddOp(peek) do
+      val op = peek.asInstanceOf[Token.Op].s
+      consume()
+      val right = parseMultiplicative()
+      left = Expr.BinOp(op, left, right)
+    left
+
+  private def parseMultiplicative(): Expr =
+    var left = parsePrimary()
+    while isMulOp(peek) do
+      val op = peek.asInstanceOf[Token.Op].s
+      consume()
+      val right = parsePrimary()
+      left = Expr.BinOp(op, left, right)
+    left
+
+  private def parsePrimary(): Expr =
+    consume() match
+      case Token.IntT(v)  => Expr.IntLit(v)
+      case Token.Ident(s) => Expr.Var(s)
+      case Token.LParen =>
+        val e = parseExpr()
+        expect(Token.RParen)
+        e
+      case t => throw new RuntimeException(s"Expected primary, got $t")
+
+  private def consumeIdent(): String =
+    consume() match
+      case Token.Ident(s) => s
+      case t              => throw new RuntimeException(s"Expected identifier, got $t")
+
+  private def isCmpOp(t: Token): Boolean = t match
+    case Token.Op(s) => Set("==", "!=", "<", "<=", ">", ">=").contains(s)
+    case _           => false
+
+  private def isAddOp(t: Token): Boolean = t match
+    case Token.Op("+") | Token.Op("-") => true
+    case _                             => false
+
+  private def isMulOp(t: Token): Boolean = t match
+    case Token.Op("*") | Token.Op("/") | Token.Op("%") => true
+    case _                                              => false

--- a/cc-native-compiler-osaka-202605/src/typescript/main.ts
+++ b/cc-native-compiler-osaka-202605/src/typescript/main.ts
@@ -1,10 +1,398 @@
-// nb-lang compiler — TypeScript skeleton
-// 実行例: npx tsx main.ts <source.nb>
-// ハンズオン中に Claude Code と一緒に埋めていきます。
+// nb-lang compiler — TypeScript reference implementation (Phase 1)
+// 実行: bun run main.ts <source.nb>
+
+import * as fs from "node:fs";
+
+// ===== AST =====
+
+type Expr =
+  | { kind: "IntLit"; value: number }
+  | { kind: "Var"; name: string }
+  | { kind: "BinOp"; op: string; left: Expr; right: Expr };
+
+type Stmt =
+  | { kind: "ValDef"; name: string; init: Expr }
+  | { kind: "VarDef"; name: string; init: Expr }
+  | { kind: "Reassign"; name: string; value: Expr }
+  | { kind: "If"; cond: Expr; thenBlk: Stmt[]; elseBlk: Stmt[] }
+  | { kind: "While"; cond: Expr; body: Stmt[] }
+  | { kind: "Print"; value: Expr };
+
+// ===== Lexer =====
+
+type Token =
+  | { kind: "Int"; value: number }
+  | { kind: "Ident"; value: string }
+  | { kind: "Kw"; value: "val" | "var" | "if" | "else" | "while" | "print" }
+  | { kind: "Op"; value: string }
+  | { kind: "LParen" }
+  | { kind: "RParen" }
+  | { kind: "LBrace" }
+  | { kind: "RBrace" }
+  | { kind: "Semi" }
+  | { kind: "EOF" };
+
+const KEYWORDS = new Set(["val", "var", "if", "else", "while", "print"]);
+
+function tokenize(src: string): Token[] {
+  const tokens: Token[] = [];
+  let i = 0;
+  const n = src.length;
+
+  while (i < n) {
+    const c = src[i];
+    if (/\s/.test(c)) { i++; continue; }
+    if (c === "/" && src[i + 1] === "/") {
+      while (i < n && src[i] !== "\n") i++;
+      continue;
+    }
+    if (/\d/.test(c)) {
+      let j = i;
+      while (j < n && /\d/.test(src[j])) j++;
+      tokens.push({ kind: "Int", value: parseInt(src.substring(i, j)) });
+      i = j;
+      continue;
+    }
+    if (/[a-zA-Z_]/.test(c)) {
+      let j = i;
+      while (j < n && /[a-zA-Z0-9_]/.test(src[j])) j++;
+      const word = src.substring(i, j);
+      if (KEYWORDS.has(word)) {
+        tokens.push({ kind: "Kw", value: word as "val" | "var" | "if" | "else" | "while" | "print" });
+      } else {
+        tokens.push({ kind: "Ident", value: word });
+      }
+      i = j;
+      continue;
+    }
+    if (c === "(") { tokens.push({ kind: "LParen" }); i++; continue; }
+    if (c === ")") { tokens.push({ kind: "RParen" }); i++; continue; }
+    if (c === "{") { tokens.push({ kind: "LBrace" }); i++; continue; }
+    if (c === "}") { tokens.push({ kind: "RBrace" }); i++; continue; }
+    if (c === ";") { tokens.push({ kind: "Semi" }); i++; continue; }
+    if (c === "=" && src[i + 1] === "=") { tokens.push({ kind: "Op", value: "==" }); i += 2; continue; }
+    if (c === "!" && src[i + 1] === "=") { tokens.push({ kind: "Op", value: "!=" }); i += 2; continue; }
+    if (c === "<" && src[i + 1] === "=") { tokens.push({ kind: "Op", value: "<=" }); i += 2; continue; }
+    if (c === ">" && src[i + 1] === "=") { tokens.push({ kind: "Op", value: ">=" }); i += 2; continue; }
+    if ("+-*/%<>=".includes(c)) { tokens.push({ kind: "Op", value: c }); i++; continue; }
+    throw new Error(`Unknown char: '${c}' at position ${i}`);
+  }
+  tokens.push({ kind: "EOF" });
+  return tokens;
+}
+
+// ===== Parser =====
+
+class Parser {
+  private pos = 0;
+
+  constructor(private readonly tokens: Token[]) {}
+
+  private peek(): Token { return this.tokens[this.pos]; }
+  private consume(): Token { return this.tokens[this.pos++]; }
+
+  parseProgram(): Stmt[] {
+    const stmts: Stmt[] = [];
+    while (this.peek().kind !== "EOF") {
+      stmts.push(this.parseStmt());
+    }
+    return stmts;
+  }
+
+  private parseStmt(): Stmt {
+    const t = this.peek();
+    if (t.kind === "Kw") {
+      switch (t.value) {
+        case "val":   return this.parseValDef();
+        case "var":   return this.parseVarDef();
+        case "if":    return this.parseIf();
+        case "while": return this.parseWhile();
+        case "print": return this.parsePrint();
+      }
+    }
+    if (t.kind === "Ident") return this.parseReassign();
+    throw new Error(`Unexpected token: ${JSON.stringify(t)}`);
+  }
+
+  private parseValDef(): Stmt {
+    this.consume(); // val
+    const name = this.consumeIdent();
+    this.expectOp("=");
+    const init = this.parseExpr();
+    this.expectSemi();
+    return { kind: "ValDef", name, init };
+  }
+
+  private parseVarDef(): Stmt {
+    this.consume(); // var
+    const name = this.consumeIdent();
+    this.expectOp("=");
+    const init = this.parseExpr();
+    this.expectSemi();
+    return { kind: "VarDef", name, init };
+  }
+
+  private parseReassign(): Stmt {
+    const name = this.consumeIdent();
+    this.expectOp("=");
+    const value = this.parseExpr();
+    this.expectSemi();
+    return { kind: "Reassign", name, value };
+  }
+
+  private parseIf(): Stmt {
+    this.consume(); // if
+    this.expectKind("LParen");
+    const cond = this.parseExpr();
+    this.expectKind("RParen");
+    const thenBlk = this.parseBlock();
+    let elseBlk: Stmt[] = [];
+    const next = this.peek();
+    if (next.kind === "Kw" && next.value === "else") {
+      this.consume();
+      elseBlk = this.parseBlock();
+    }
+    return { kind: "If", cond, thenBlk, elseBlk };
+  }
+
+  private parseWhile(): Stmt {
+    this.consume(); // while
+    this.expectKind("LParen");
+    const cond = this.parseExpr();
+    this.expectKind("RParen");
+    const body = this.parseBlock();
+    return { kind: "While", cond, body };
+  }
+
+  private parsePrint(): Stmt {
+    this.consume(); // print
+    this.expectKind("LParen");
+    const value = this.parseExpr();
+    this.expectKind("RParen");
+    this.expectSemi();
+    return { kind: "Print", value };
+  }
+
+  private parseBlock(): Stmt[] {
+    this.expectKind("LBrace");
+    const stmts: Stmt[] = [];
+    while (this.peek().kind !== "RBrace") {
+      stmts.push(this.parseStmt());
+    }
+    this.consume(); // }
+    return stmts;
+  }
+
+  private parseExpr(): Expr { return this.parseComparison(); }
+
+  private parseComparison(): Expr {
+    let left = this.parseAdditive();
+    while (this.isOp(["==", "!=", "<", "<=", ">", ">="])) {
+      const op = (this.consume() as { kind: "Op"; value: string }).value;
+      const right = this.parseAdditive();
+      left = { kind: "BinOp", op, left, right };
+    }
+    return left;
+  }
+
+  private parseAdditive(): Expr {
+    let left = this.parseMultiplicative();
+    while (this.isOp(["+", "-"])) {
+      const op = (this.consume() as { kind: "Op"; value: string }).value;
+      const right = this.parseMultiplicative();
+      left = { kind: "BinOp", op, left, right };
+    }
+    return left;
+  }
+
+  private parseMultiplicative(): Expr {
+    let left = this.parsePrimary();
+    while (this.isOp(["*", "/", "%"])) {
+      const op = (this.consume() as { kind: "Op"; value: string }).value;
+      const right = this.parsePrimary();
+      left = { kind: "BinOp", op, left, right };
+    }
+    return left;
+  }
+
+  private parsePrimary(): Expr {
+    const t = this.consume();
+    if (t.kind === "Int") return { kind: "IntLit", value: t.value };
+    if (t.kind === "Ident") return { kind: "Var", name: t.value };
+    if (t.kind === "LParen") {
+      const e = this.parseExpr();
+      this.expectKind("RParen");
+      return e;
+    }
+    throw new Error(`Expected primary, got ${JSON.stringify(t)}`);
+  }
+
+  private isOp(values: string[]): boolean {
+    const t = this.peek();
+    return t.kind === "Op" && values.includes(t.value);
+  }
+
+  private consumeIdent(): string {
+    const t = this.consume();
+    if (t.kind !== "Ident") throw new Error(`Expected identifier, got ${JSON.stringify(t)}`);
+    return t.value;
+  }
+
+  private expectOp(value: string): void {
+    const t = this.consume();
+    if (t.kind !== "Op" || t.value !== value) {
+      throw new Error(`Expected '${value}', got ${JSON.stringify(t)}`);
+    }
+  }
+
+  private expectKind(kind: Token["kind"]): void {
+    const t = this.consume();
+    if (t.kind !== kind) throw new Error(`Expected ${kind}, got ${JSON.stringify(t)}`);
+  }
+
+  private expectSemi(): void { this.expectKind("Semi"); }
+}
+
+// ===== CodeGen =====
+
+class CodeGen {
+  private lines: string[] = [];
+  private tempCounter = 0;
+  private labelCounter = 0;
+
+  private fresh(): string {
+    this.tempCounter++;
+    return `%t${this.tempCounter}`;
+  }
+
+  private freshLabel(prefix: string): string {
+    this.labelCounter++;
+    return `${prefix}${this.labelCounter}`;
+  }
+
+  private emit(line: string): void { this.lines.push(line); }
+
+  private detectTriple(): string {
+    return process.platform === "darwin"
+      ? "arm64-apple-macosx15.0.0"
+      : "x86_64-pc-linux-gnu";
+  }
+
+  gen(program: Stmt[]): string {
+    this.emit("; ModuleID = 'nb-lang'");
+    this.emit(`target triple = "${this.detectTriple()}"`);
+    this.emit("");
+    this.emit('@fmt = private constant [5 x i8] c"%ld\\0A\\00"');
+    this.emit("declare i32 @printf(ptr, ...)");
+    this.emit("");
+    this.emit("define i32 @main() {");
+    this.emit("entry:");
+    for (const s of program) this.genStmt(s);
+    this.emit("  ret i32 0");
+    this.emit("}");
+    return this.lines.join("\n") + "\n";
+  }
+
+  private genStmt(s: Stmt): void {
+    switch (s.kind) {
+      case "ValDef":
+      case "VarDef": {
+        this.emit(`  %${s.name} = alloca i64, align 8`);
+        const v = this.genExpr(s.init);
+        this.emit(`  store i64 ${v}, ptr %${s.name}`);
+        break;
+      }
+      case "Reassign": {
+        const v = this.genExpr(s.value);
+        this.emit(`  store i64 ${v}, ptr %${s.name}`);
+        break;
+      }
+      case "Print": {
+        const v = this.genExpr(s.value);
+        this.emit(`  call i32 (ptr, ...) @printf(ptr @fmt, i64 ${v})`);
+        break;
+      }
+      case "If": {
+        const c = this.genExpr(s.cond);
+        const ci1 = this.fresh();
+        this.emit(`  ${ci1} = icmp ne i64 ${c}, 0`);
+        const thenL = this.freshLabel("then");
+        const elseL = this.freshLabel("else");
+        const endL  = this.freshLabel("ifend");
+        this.emit(`  br i1 ${ci1}, label %${thenL}, label %${elseL}`);
+        this.emit(`${thenL}:`);
+        for (const st of s.thenBlk) this.genStmt(st);
+        this.emit(`  br label %${endL}`);
+        this.emit(`${elseL}:`);
+        for (const st of s.elseBlk) this.genStmt(st);
+        this.emit(`  br label %${endL}`);
+        this.emit(`${endL}:`);
+        break;
+      }
+      case "While": {
+        const condL = this.freshLabel("cond");
+        const bodyL = this.freshLabel("body");
+        const exitL = this.freshLabel("exit");
+        this.emit(`  br label %${condL}`);
+        this.emit(`${condL}:`);
+        const c = this.genExpr(s.cond);
+        const ci1 = this.fresh();
+        this.emit(`  ${ci1} = icmp ne i64 ${c}, 0`);
+        this.emit(`  br i1 ${ci1}, label %${bodyL}, label %${exitL}`);
+        this.emit(`${bodyL}:`);
+        for (const st of s.body) this.genStmt(st);
+        this.emit(`  br label %${condL}`);
+        this.emit(`${exitL}:`);
+        break;
+      }
+    }
+  }
+
+  private genExpr(e: Expr): string {
+    switch (e.kind) {
+      case "IntLit": return e.value.toString();
+      case "Var": {
+        const r = this.fresh();
+        this.emit(`  ${r} = load i64, ptr %${e.name}`);
+        return r;
+      }
+      case "BinOp": {
+        const lv = this.genExpr(e.left);
+        const rv = this.genExpr(e.right);
+        const res = this.fresh();
+        const arith: Record<string, string> = {
+          "+": "add", "-": "sub", "*": "mul", "/": "sdiv", "%": "srem"
+        };
+        const cmp: Record<string, string> = {
+          "==": "eq", "!=": "ne", "<": "slt", "<=": "sle", ">": "sgt", ">=": "sge"
+        };
+        if (arith[e.op]) {
+          this.emit(`  ${res} = ${arith[e.op]} i64 ${lv}, ${rv}`);
+        } else if (cmp[e.op]) {
+          const tmp = this.fresh();
+          this.emit(`  ${tmp} = icmp ${cmp[e.op]} i64 ${lv}, ${rv}`);
+          this.emit(`  ${res} = zext i1 ${tmp} to i64`);
+        } else {
+          throw new Error(`Unknown op: ${e.op}`);
+        }
+        return res;
+      }
+    }
+  }
+}
+
+// ===== Main =====
 
 const args = process.argv.slice(2);
 if (args.length === 0) {
-  console.log("usage: npx tsx main.ts <source.nb>");
-} else {
-  console.log(`TODO: compile ${args[0]}`);
+  console.error("usage: bun run main.ts <source.nb>");
+  process.exit(1);
 }
+
+const src = fs.readFileSync(args[0], "utf-8");
+const tokens = tokenize(src);
+const parser = new Parser(tokens);
+const program = parser.parseProgram();
+const codegen = new CodeGen();
+const ir = codegen.gen(program);
+process.stdout.write(ir);


### PR DESCRIPTION
## 概要

5/21 開催「Claude Codeで作るネイティブコンパイラ in 大阪」の配布物を、ハンズオン本番で確実に機能するレベルまで詰めました。

## 変更点

### `prompts/backend-strategy.md`
- macOS arm64 / Linux x86-64 の **2 バリアント triple** を明示
- Apple clang 16+ の **opaque pointer (`ptr`)** に統一（typed pointer 廃止）
- Phase 1 / 2 / 3 の IR サンプル全て、**手元で動作検証済み**（macOS arm64）
  - Hello World (`42`)
  - Phase 1 統合: 1〜10 の和 (`55`)
  - Phase 2: 階乗 5 (`120`)
  - Phase 3: 文字列 (`hello`)
  - Phase 3: リスト (`15`)
- フォールバック戦略を **3 プラン** に拡張（A: LLVM IR / B: C 経由 / C: アセンブリ .s）

### `prompts/language-spec.md`
- 型推論の最小ルール明文化
- 3 言語別の AST 設計例（Scala 3 enum / TS discriminated union / Java sealed interface+record）
- 3 言語別の完成プロンプト（コピペ可）
- 詰まった時の対話プロンプト集 5 種

### `src/{scala3,typescript,java}/` リファレンス実装
3 言語それぞれで Phase 1 を実装、`examples/sum.nb` で `55` 出力を確認：

| 言語 | 実行コマンド | 動作確認 |
|------|------|------|
| Scala 3 | `scala-cli run . -- ../examples/sum.nb` | ✓ macOS arm64 |
| TypeScript (Bun) | `bun run main.ts ../examples/sum.nb` | ✓ macOS arm64 |
| Java | `java Main.java ../examples/sum.nb` | ✓ macOS arm64 (Java 25) |

各言語、AST 定義 → Lexer → Parser → CodeGen → Main の構成。

### TypeScript: Node.js + tsx → Bun に統一
- `bun run main.ts <source.nb>` で直接実行、`tsx` 不要

## 残作業

- Linux x86-64 / WSL2 環境での動作検証
- Phase 2/3 のリファレンス実装（Phase 1 だけでも十分との判断）
- スライドの中身詰め

## テストプラン

- [x] macOS arm64 で 3 言語すべての `sum.nb` で `55` 出力確認
- [x] Hello World / Phase 1〜3 の IR を `clang` でビルドして期待値出力確認
- [ ] Linux x86-64 / WSL2 で sum.nb 動作確認（target triple 切替で）
- [ ] バックエンド戦略 Hello World IR の Linux ビルド確認