### PR TITLE
ハンズオン後半向け：言語拡張チャレンジ（Medium 4本）追加

### DIFF
--- a/cc-native-compiler-osaka-202605/README.md
+++ b/cc-native-compiler-osaka-202605/README.md
@@ -13,7 +13,7 @@
 
 1. **C/C++ ツールチェイン**（`clang` と LLVM ツール一式の両方）
 2. **実装言語の処理系 + ビルドツール**（Scala 3 + sbt / TypeScript + Bun / Java + Maven のうちお好きなもの 1 つ）
-3. **Claude Code**
+3. **Claude Code または Codex**（どちらでも OK）
 
 ---
 
@@ -137,16 +137,20 @@ mvn --version
 
 ---
 
-### 3. Claude Code
+### 3. Claude Code または Codex
 
-[Claude Code](https://docs.claude.com/en/docs/claude-code/overview) のセットアップが
-済んでいて、ターミナルから対話できる状態にしておいてください。
+エージェント CLI は **Claude Code / Codex のどちらでも OK**です。普段使い慣れている方を、
+ターミナルから対話できる状態にしておいてください。
+
+- [Claude Code](https://docs.claude.com/en/docs/claude-code/overview)
+- [Codex CLI](https://github.com/openai/codex)
 
 ```bash
-claude --version       # 動作確認
+claude --version       # Claude Code を使う人
+codex --version        # Codex を使う人
 ```
 
-API キー / サブスクリプションのどちらかで認証されていれば OK。
+それぞれ API キー / サブスクリプションのどちらかで認証されていれば OK。
 
 ---
 
@@ -165,8 +169,9 @@ bun --version          # TypeScript を選んだ人
 mvn --version          # Java を選んだ人
 java --version         # Scala 3 / Java を選んだ人
 
-# Claude Code
+# Claude Code または Codex（どちらか）
 claude --version
+codex --version
 ```
 
 そのうえで、リポジトリの `cc-native-compiler-osaka-202605/langs/<言語>/` を
@@ -206,7 +211,7 @@ clang examples/sum.ll -o examples/sum.out && ./examples/sum.out   # → 55
 - **TypeScript (Bun)** → `prompts/typescript.md`
 - **Java** → `prompts/java.md`
 
-ハンズオン中は自分の言語の `prompts/<言語>.md` **1 ファイル**だけ Claude Code に渡せば OK。
+ハンズオン中は自分の言語の `prompts/<言語>.md` **1 ファイル**だけ Claude Code / Codex に渡せば OK。
 
 ### リファレンス実装（参考用、3 言語とも標準レイアウト）
 

--- a/cc-native-compiler-osaka-202605/prompts/ext-break-continue.md
+++ b/cc-native-compiler-osaka-202605/prompts/ext-break-continue.md
@@ -1,0 +1,106 @@
+# 言語拡張プロンプト：`break` / `continue`
+
+> nb-lang の **既に動いている実装**に `break` / `continue` 文を追加するためのプロンプト。
+> Claude Code / Codex に `prompts/<言語>.md` と一緒に、または完成済みの実装に追加で渡してください。
+
+## 仕様
+
+`while` ループの中で **早期脱出** と **次イテレーションへスキップ** を可能にする：
+
+```
+var i = 0;
+var sum = 0;
+while (i < 100) {
+  i = i + 1;
+  if (i % 2 == 0) {
+    continue;       // 偶数はスキップ
+  }
+  if (sum > 50) {
+    break;          // sum が 50 超えたら脱出
+  }
+  sum = sum + i;
+}
+print(sum);
+```
+
+期待出力（1+3+5+...+15 = 64 を超えた直後で脱出するので **64**）：
+```
+64
+```
+
+## 各層への変更点
+
+### Lexer
+- キーワード `break`, `continue` を追加（`KEYWORDS` セットに足すだけ）
+
+### Parser
+- `parseStatement` に `break;` `continue;` を受ける分岐を追加
+- パース時点ではループ外で使われてもエラーにしない（CodeGen 側で扱う or TypeCheck で拒否）
+
+### AST
+- `Stmt` に 2 つのケースを追加：`Break`, `Continue`（引数なし）
+
+### TypeCheck（任意）
+- 厳密にやるなら「ループ外での break/continue はエラー」をここで検出する
+- ループ深さを `int` で持ち回るか、`inLoop: bool` フラグで判定
+
+### CodeGen — **ここが本題**
+- **ループラベルのスタック** を CodeGen クラスに持つ。
+  - 例: `private val loopStack = mutable.Stack[(condLbl, endLbl)]()`
+  - while に入るとき push、抜けるとき pop
+- `Break` の CodeGen: `br label %<endLbl>` を出して、その basic block を terminated 扱いに
+- `Continue` の CodeGen: `br label %<condLbl>` を出して、同じく terminated 扱い
+- terminator 直後にコードを出さないよう、`genStmts` の `terminated` ロジックと整合させる
+
+### 注意：basic block の terminator 重複に気をつける
+
+`break;` の後に同じブロック内でコードが続くと、LLVM IR では到達不能。
+既存実装の `genStmts` が `terminated` を返す仕組みになっているはずなので、
+`Break` / `Continue` でも `terminated = true` を返してその後の文生成を打ち切ること。
+
+## 追加テスト
+
+`examples/ext_break.nb`：
+```
+var i = 0;
+var sum = 0;
+while (i < 100) {
+  i = i + 1;
+  if (i % 2 == 0) {
+    continue;
+  }
+  if (sum > 50) {
+    break;
+  }
+  sum = sum + i;
+}
+print(sum);
+```
+→ `64`
+
+`examples/ext_continue.nb`（純 continue）：
+```
+var i = 0;
+var s = 0;
+while (i < 10) {
+  i = i + 1;
+  if (i == 5) {
+    continue;
+  }
+  s = s + i;
+}
+print(s);
+```
+→ `1+2+3+4+6+7+8+9+10 = 50`
+
+## プロンプト雛形（コピペ可）
+
+```text
+@prompts/<言語>.md で作った nb-lang の実装に、break / continue 文を追加してください。
+仕様と各層の変更点は以下のとおりです。
+
+（このファイルの「仕様」と「各層への変更点」セクションをペースト）
+
+追加後、examples/ext_break.nb が 64、examples/ext_continue.nb が 50 を出すことを
+確認してください。既存テスト（sum.nb / fact.nb / strlist.nb）が壊れていないことも併せて検証。
+```

--- a/cc-native-compiler-osaka-202605/prompts/ext-for-loop.md
+++ b/cc-native-compiler-osaka-202605/prompts/ext-for-loop.md
@@ -1,0 +1,134 @@
+# 言語拡張プロンプト：C 風 `for` ループ
+
+> nb-lang の **既に動いている実装**に C 風 `for` ループを追加するためのプロンプト。
+> Claude Code / Codex に `prompts/<言語>.md` と一緒に、または完成済みの実装に追加で渡してください。
+
+## 仕様
+
+C 風 3 つ組の `for (init; cond; step) { body }` を追加：
+
+```
+for (var i = 0; i < 5; i = i + 1) {
+  print(i);
+}
+```
+期待出力：
+```
+0
+1
+2
+3
+4
+```
+
+意味論は **`while` への糖衣構文**：
+
+```
+for (INIT; COND; STEP) { BODY }
+```
+は
+
+```
+{
+  INIT
+  while (COND) {
+    BODY
+    STEP;
+  }
+}
+```
+と等価。INIT は `val` / `var` / 単純な代入を許可。STEP は `Reassign`（`x = expr`）。
+INIT で導入した変数は for の中だけで有効（ブロックスコープ）。
+
+## 各層への変更点
+
+### Lexer
+- キーワード `for` を追加（`KEYWORDS` セットに足すだけ）
+
+### Parser
+- `parseStatement` に `for (INIT COND ; STEP) BLOCK` を追加：
+  ```
+  for-stmt = "for" "(" stmt-init expr ";" stmt-step ")" block ;
+  stmt-init = val-def | var-def | reassign | ";"  // 空 init は ";" 単体
+  stmt-step = reassign  // 単純化のため reassign のみ
+  ```
+- 注意：INIT は **末尾の `;` を含む文**として読む（val-def / var-def は元から `;` で終わるので素直）
+
+### AST — 2 つの方針
+
+**方針 A：専用ノード `For(init, cond, step, body)` を追加**
+- enum / sealed interface / discriminated union に `For` を追加
+- CodeGen で別途処理
+
+**方針 B：パース時に `While` + 補助に展開（desugar）**
+- AST には新ノードを追加しない
+- Parser が `for (INIT; COND; STEP) { BODY }` を見たら、内部で
+  `[INIT, While(COND, BODY ++ [STEP])]` 相当の AST を構築
+
+**方針 B の方が CodeGen 修正不要で楽**。教育的には方針 A も悪くない（再帰下降の構造を素直に保てる）。
+
+### TypeCheck
+- 方針 A なら `For` ケースを追加：init/step を環境付きで再帰的に check、cond は int
+- 方針 B なら自動で型検査が通る
+
+### CodeGen
+- 方針 A なら `For` ケースを追加：エントリで init を実行、その後 while と同じ basic block 構造
+- 方針 B なら修正不要
+
+## 追加テスト
+
+`examples/ext_for.nb`（基本）：
+```
+for (var i = 0; i < 5; i = i + 1) {
+  print(i);
+}
+```
+期待出力：`0` `1` `2` `3` `4`
+
+`examples/ext_for_sum.nb`（合計）：
+```
+var total = 0;
+for (var i = 1; i <= 10; i = i + 1) {
+  total = total + i;
+}
+print(total);
+```
+期待出力：`55`
+
+`examples/ext_for_scope.nb`（スコープ確認・オプション）：
+```
+var i = 100;
+for (var i = 0; i < 3; i = i + 1) {
+  print(i);
+}
+print(i);
+```
+期待出力（外側の `i` は 100 のまま）：
+```
+0
+1
+2
+100
+```
+※ ブロックスコープが面倒なら、この挙動は省略しても OK（参加者の判断）。
+
+## プロンプト雛形（コピペ可）
+
+```text
+@prompts/<言語>.md で作った nb-lang の実装に、C 風の for ループを追加してください。
+
+  for (INIT; COND; STEP) { BODY }
+
+は
+
+  INIT
+  while (COND) { BODY; STEP; }
+
+と等価です。実装方針は **AST に専用 For ノードを足す** または
+**Parser で while に desugar する** のどちらでも構いません（前者推奨：教育的）。
+
+（このファイルの「仕様」と「各層への変更点」セクションをペースト）
+
+追加後、examples/ext_for.nb が 0〜4 を、examples/ext_for_sum.nb が 55 を出すことを
+確認してください。既存テスト（sum.nb / fact.nb / strlist.nb）が壊れていないことも併せて検証。
+```

--- a/cc-native-compiler-osaka-202605/prompts/ext-logical-ops.md
+++ b/cc-native-compiler-osaka-202605/prompts/ext-logical-ops.md
@@ -1,0 +1,162 @@
+# 言語拡張プロンプト：`&&` / `||` / `!`（短絡評価）
+
+> nb-lang の **既に動いている実装**に論理演算子（短絡評価）を追加するためのプロンプト。
+> Claude Code / Codex に `prompts/<言語>.md` と一緒に、または完成済みの実装に追加で渡してください。
+
+## 仕様
+
+論理演算 3 種を **短絡評価**で実装する：
+
+- `a && b` — `a` が偽（`0`）なら `b` は評価せず `0` を返す
+- `a || b` — `a` が真（非 `0`）なら `b` は評価せず `1` を返す
+- `!a`     — `a` が偽（`0`）なら `1`、それ以外は `0`
+
+優先順位（低い順）：
+```
+|| < && < == != < > <= >= < + - < * / % < unary（! と -）
+```
+
+例：
+```
+val x = 5;
+if (x > 0 && x < 10) {
+  print(1);
+}
+if (x == 0 || x == 5) {
+  print(2);
+}
+print(!0);
+print(!1);
+```
+期待出力：
+```
+1
+2
+1
+0
+```
+
+## 各層への変更点
+
+### Lexer
+- 2 文字オペレータ `&&` / `||` を追加（既存の `==` `!=` `<=` `>=` と同じ扱い）
+- 1 文字オペレータ `!` を追加
+
+### Parser
+- 優先順位レベルを 2 段増やす：
+  ```
+  expr           = orExpr ;
+  orExpr         = andExpr ( "||" andExpr )* ;
+  andExpr        = comparison ( "&&" comparison )* ;
+  comparison     = additive ( cmpOp additive )* ;
+  ...
+  unary          = ( "-" | "!" ) postfix | postfix ;
+  ```
+- `!` は unary で吸収する
+
+### AST
+- `Expr` に追加：`And(l, r)`, `Or(l, r)`, `Not(e)`
+- `BinOp` で表現してもいいが、**短絡評価のため CodeGen で特別扱いが必要**なので、専用ノードにする方が綺麗
+
+### TypeCheck
+- `&&` `||` `!` の引数は **int**（bool 兼用、0/1 を期待）
+- 結果も int
+
+### CodeGen — **ここが本題**
+
+`a && b` の **短絡評価** を basic block で表現：
+
+```llvm
+  ; 評価 a → %a
+  %a = ...
+  %a.bool = icmp ne i64 %a, 0
+  br i1 %a.bool, label %and.rhs, label %and.end
+
+and.rhs:
+  ; 評価 b → %b
+  %b = ...
+  %b.bool = icmp ne i64 %b, 0
+  %b.i64 = zext i1 %b.bool to i64
+  br label %and.end
+
+and.end:
+  %and.result = phi i64 [ 0, %<entry前ブロック> ], [ %b.i64, %and.rhs ]
+```
+
+`||` は then/else の真偽が逆になるだけ。`!` は単純に `icmp eq i64 %x, 0` → `zext`。
+
+**ポイント：`phi` を使うのが SSA らしい書き方**。`phi` の `[ value, predecessor ]` で
+「どの直前ブロックから来たか」を指定する。entry block の名前を正しく追跡する必要があるので、
+genExpr が現在の basic block 名を返せるよう少しリファクタが必要。
+
+**代替案（phi を避ける）：** alloca した一時変数に書き込む方式でも OK。
+コードはやや冗長になるが、既存の env スタイルと整合する。
+
+```llvm
+  %tmp = alloca i64
+  store i64 0, ptr %tmp
+  %a = ...
+  %a.bool = icmp ne i64 %a, 0
+  br i1 %a.bool, label %and.rhs, label %and.end
+and.rhs:
+  %b = ...
+  %b.bool = icmp ne i64 %b, 0
+  %b.i64 = zext i1 %b.bool to i64
+  store i64 %b.i64, ptr %tmp
+  br label %and.end
+and.end:
+  %and.result = load i64, ptr %tmp
+```
+
+## 追加テスト
+
+`examples/ext_logical.nb`：
+```
+val x = 5;
+if (x > 0 && x < 10) {
+  print(1);
+}
+if (x == 0 || x == 5) {
+  print(2);
+}
+print(!0);
+print(!1);
+```
+期待出力：
+```
+1
+2
+1
+0
+```
+
+短絡評価の確認用 `examples/ext_short_circuit.nb`：
+```
+function side(): int {
+  print(99);     // この行が呼ばれたら短絡失敗
+  return 1;
+}
+
+if (0 && side()) {
+  print(0);
+} else {
+  print(1);      // こちらだけが出るはず
+}
+```
+期待出力（99 は出ない）：
+```
+1
+```
+
+## プロンプト雛形（コピペ可）
+
+```text
+@prompts/<言語>.md で作った nb-lang の実装に、論理演算子 && / || / ! を追加してください。
+**必ず短絡評価で実装**してください（右辺を不要に評価しない）。
+
+（このファイルの「仕様」と「各層への変更点」セクションをペースト）
+
+追加後、examples/ext_logical.nb が "1\n2\n1\n0" を、
+examples/ext_short_circuit.nb が "1"（99 は出ない）を出すことを確認してください。
+既存テスト（sum.nb / fact.nb / strlist.nb）が壊れていないことも併せて検証。
+```

--- a/cc-native-compiler-osaka-202605/prompts/ext-string-concat.md
+++ b/cc-native-compiler-osaka-202605/prompts/ext-string-concat.md
@@ -1,0 +1,121 @@
+# 言語拡張プロンプト：`string + string` 連結
+
+> nb-lang の **既に動いている実装**に文字列連結を追加するためのプロンプト。
+> Claude Code / Codex に `prompts/<言語>.md` と一緒に、または完成済みの実装に追加で渡してください。
+
+## 仕様
+
+`+` 演算子を **string + string → string** にもオーバーロードする。
+両辺の型が一致しているときだけ動く（`int + string` などは引き続き型エラー）。
+
+```
+val a = "hello, ";
+val b = "world";
+print(a + b);
+
+function greet(name: string): string {
+  return "Hello, " + name + "!";
+}
+print(greet("Osaka"));
+```
+期待出力：
+```
+hello, world
+Hello, Osaka!
+```
+
+## 各層への変更点
+
+### Lexer / Parser / AST
+- **変更不要**。既存の `BinOp("+", a, b)` をそのまま流用する。
+
+### TypeCheck
+- 現状の `+` ルール（両辺 int → int）を拡張：
+  - 両辺 `int` → `int`
+  - 両辺 `string` → `string`
+  - それ以外 → エラー（既存の挙動を維持）
+- それ以外の演算子（`-` `*` `/` `%` 比較）は **int のみ**。string は許さない。
+
+### CodeGen — **ここが本題**
+
+C ランタイム関数を呼び出す。グローバルに外部宣言を追加：
+
+```llvm
+declare i64 @strlen(ptr)
+declare ptr @malloc(i64)
+declare ptr @strcpy(ptr, ptr)
+declare ptr @strcat(ptr, ptr)
+```
+
+`s1 + s2` の生成パターン：
+
+```llvm
+  ; %s1, %s2 が ptr で評価済みとする
+  %len1 = call i64 @strlen(ptr %s1)
+  %len2 = call i64 @strlen(ptr %s2)
+  %sum  = add i64 %len1, %len2
+  %size = add i64 %sum, 1                      ; NUL 終端の 1 バイト
+  %buf  = call ptr @malloc(i64 %size)
+  %_1   = call ptr @strcpy(ptr %buf, ptr %s1)
+  %_2   = call ptr @strcat(ptr %buf, ptr %s2)
+  ; 結果は %buf
+```
+
+**注意：**
+- `BinOp` の CodeGen 分岐で、現在は op + 整数演算しか処理していないはず。
+  `+` のときに左右の型を見て `string + string` なら上のシーケンスを出す
+- 既存実装で **両辺の型が一致しているか TypeCheck が保証** しているので、
+  CodeGen では `op == "+" && lt == TString` 1 条件で分岐すればよい
+- `malloc` しっぱなし方針なので `free` は呼ばない
+
+## 追加テスト
+
+`examples/ext_strcat.nb`（基本）：
+```
+val a = "hello, ";
+val b = "world";
+print(a + b);
+```
+期待出力：`hello, world`
+
+`examples/ext_strcat_chain.nb`（連鎖 + 関数）：
+```
+function greet(name: string): string {
+  return "Hello, " + name + "!";
+}
+print(greet("Osaka"));
+```
+期待出力：`Hello, Osaka!`
+
+`examples/ext_strcat_var.nb`（var で蓄積）：
+```
+var msg = "";
+msg = msg + "a";
+msg = msg + "b";
+msg = msg + "c";
+print(msg);
+```
+期待出力：`abc`
+
+## プロンプト雛形（コピペ可）
+
+```text
+@prompts/<言語>.md で作った nb-lang の実装に、`string + string` の連結演算を追加してください。
+
+TypeCheck で `+` のルールを拡張：
+- int + int → int（既存）
+- string + string → string（新規）
+
+CodeGen で string 連結を実装：
+- declare i64 @strlen(ptr)
+- declare ptr @malloc(i64)
+- declare ptr @strcpy(ptr, ptr)
+- declare ptr @strcat(ptr, ptr)
+を追加し、malloc(len1 + len2 + 1) → strcpy → strcat の手順で新しい文字列を作る。
+
+（このファイルの「仕様」と「各層への変更点」セクションをペースト）
+
+追加後、examples/ext_strcat.nb / ext_strcat_chain.nb / ext_strcat_var.nb が
+それぞれ "hello, world" / "Hello, Osaka!" / "abc" を出すことを確認してください。
+既存テスト（sum.nb / fact.nb / strlist.nb）が壊れていないことも併せて検証。
+```

--- a/cc-native-compiler-osaka-202605/slide.md
+++ b/cc-native-compiler-osaka-202605/slide.md
@@ -66,7 +66,7 @@ mermaid.initialize({
 
 今日のテーマは、一段踏み込んで：
 
-- **Claude Codeを相棒に、小さな言語のネイティブコンパイラを書く**
+- **Claude Code / Codex を相棒に、小さな言語のネイティブコンパイラを書く**
 - 生成された artifacts から実バイナリが生まれ、`./a.out` で動く
 - **エージェント時代のコンパイラ開発の感触**を実地で確かめる
 
@@ -88,7 +88,7 @@ mermaid.initialize({
    - 実装言語は **Scala 3 (sbt) / TypeScript (Bun) / Java (Maven)** からお好きなものを
    - 整数演算 / 変数 / if / while / print
    - 出力：LLVM IR → clang でリンク → 実バイナリ
-2. **Claude Code との協業設計**を体験する
+2. **Claude Code / Codex との協業設計**を体験する
    - 丸投げする部分と、人間が指揮する部分の切り分け
 3. 動くバイナリでなんかする
    - `./a.out` を叩いて結果を見る達成感
@@ -107,38 +107,101 @@ mermaid.initialize({
 
 ---
 
+## ハンズオン開始：リポジトリ準備
+
+まずはリポジトリを clone してください。プロンプトとリファレンス実装が入っています。
+
+```bash
+git clone git@github.com:nextbeat-dev/nextbeat-tech-event.git
+cd nextbeat-tech-event/cc-native-compiler-osaka-202605
+```
+
+ブラウザで中身を確認したい人はこちら：
+**https://github.com/nextbeat-dev/nextbeat-tech-event/tree/main/cc-native-compiler-osaka-202605**
+
+---
+
+## ハンズオン開始：作業ディレクトリの用意
+
+clone したリポジトリは「配布物」。書き換えるのではなく、別場所に作業ディレクトリを切ります：
+
+```bash
+mkdir -p ~/work/nblang && cd ~/work/nblang
+claude    # Claude Code
+# または
+codex     # Codex CLI
+```
+
+エージェント CLI は **Claude Code / Codex のどちらでも OK**。起動したら、
+自分の言語に応じて以下のプロンプトファイルを参照：
+
+| 言語          | 参照するファイル                                                              |
+| ------------- | ----------------------------------------------------------------------------- |
+| Scala 3       | `~/.../cc-native-compiler-osaka-202605/prompts/scala3.md`                     |
+| TypeScript    | `~/.../cc-native-compiler-osaka-202605/prompts/typescript.md`                 |
+| Java          | `~/.../cc-native-compiler-osaka-202605/prompts/java.md`                       |
+
+各ファイルに **言語仕様 + LLVM IR バックエンド戦略 + AST 設計例 + 初期プロンプト + 対話例**
+が全部入りの自己完結プロンプトです。1 ファイルだけ Claude Code / Codex に渡せば OK。
+
+---
+
 ## ハンズオン（前半 30分）
 
 **Step 1: AST と字句・構文解析**
 
-Claude Code に自分の言語の `prompts/<言語>.md`（`prompts/scala3.md` /
-`prompts/typescript.md` / `prompts/java.md`）を渡してスタート。
-各ファイルに **言語仕様＋LLVM IR バックエンド戦略＋初期プロンプト**
-が全部入っています。
+Claude Code もしくは Codex を起動して、自分の言語のプロンプト 1 ファイルを `@` で渡してスタート。
 
-> 以下の仕様の小言語 "nb-lang" のネイティブコンパイラを作ってください。
-> - 整数リテラル / 四則演算 / 変数代入 / if / while / print
-> - 標準レイアウト（pom.xml / build.sbt / package.json）で
-> - (以下略、詳細は配布プロンプト)
+```text
+@~/.../cc-native-compiler-osaka-202605/prompts/scala3.md
+
+このプロンプトに従って、nb-lang のネイティブコンパイラを Phase 1 から作ってください。
+最初のゴールは examples/sum.nb が 55 を出すところまで。
+```
+
+困ったときの参考実装は **`langs/{scala3,typescript,java}/`** 配下にあります
+（前者は配布リポジトリ、ここを覗くのはカンニング OK ということで）。
 
 ---
 
-## ハンズオン（後半 30分）
+## ハンズオン（後半 30分）：言語拡張チャレンジ
 
-**Step 2: LLVM IR コード生成**
+前半で Phase 1〜3 が動いたら、後半は **自分のコンパイラに機能を足す** ターン。
+4 つの拡張プロンプトを `prompts/ext-*.md` に用意しています。
 
-<!-- TODO: コード生成の勘所、Claude Code との詰め方 -->
+| 拡張                  | プロンプト                       | 触る場所                  | 達成感                       |
+| --------------------- | -------------------------------- | ------------------------- | ---------------------------- |
+| `break` / `continue`  | `prompts/ext-break-continue.md`  | Lexer/Parser/AST/CodeGen  | basic block の感触◎          |
+| `&&` / `\|\|` / `!`   | `prompts/ext-logical-ops.md`     | Lexer/Parser/AST/CodeGen  | **短絡評価**を IR で表現     |
+| C 風 `for`            | `prompts/ext-for-loop.md`        | Lexer/Parser (+ CodeGen)  | while への desugar 体験      |
+| `string + string`     | `prompts/ext-string-concat.md`   | TypeCheck/CodeGen         | 外部ランタイム関数の呼び出し |
 
-- SSA 形式の IR を吐く
-- レジスタ割り当ては LLVM 任せ
-- 制御フロー：basic block とラベル
-- `printf` の外部宣言と呼び出し
+好きなのを **1 個選んで**ぶん投げ。複数いけたらボーナス。
+
+---
+
+## 言語拡張チャレンジ：投げ方の例
+
+Claude Code / Codex に **自分の言語の prompt** ＋ **拡張 prompt** を一緒に渡す：
+
+```text
+@~/.../cc-native-compiler-osaka-202605/prompts/scala3.md
+@~/.../cc-native-compiler-osaka-202605/prompts/ext-logical-ops.md
+
+このプロンプトに従って、既存の実装に && / || / ! を短絡評価で追加してください。
+追加後、examples/ext_logical.nb と ext_short_circuit.nb で動作を確認してください。
+```
+
+各 `ext-*.md` には **仕様 / 各層の変更点 / テストプログラム / 期待出力 / プロンプト雛形**
+が全部入っているので、Claude Code / Codex は迷いません。
+
+困ったら参考実装 `langs/<言語>/` を覗いて差分を相談するのも有効。
 
 ---
 
 ## まとめ
 
-- Claude Code で **1 時間あればネイティブコンパイラは書ける**
+- Claude Code / Codex で **1 時間あればネイティブコンパイラは書ける**
 - 肝は「**仕様と戦略を人間が決める、実装は預ける**」
 - 型と ABI の境界で人間の介入が必要になる
 - 今日のコードは各自の GitHub で育ててください


### PR DESCRIPTION
## Summary

ハンズオン前半（Phase 1〜3 で nb-lang コンパイラを作る）が瞬殺で終わる可能性に備えて、後半 30 分用の **言語拡張チャレンジ**を整備しました。

- `prompts/ext-*.md` に Medium 難度の拡張プロンプトを 4 本追加
- 各拡張は **仕様 / 各層の変更点 / テストプログラム / プロンプト雛形** が全部入りで、Claude Code / Codex に渡すだけで実装まで完結する想定
- slide.md の後半 30 分のスライドを「言語拡張チャレンジ」に差し替え（お品書き + 投げ方の例）
- ついでに slide.md / README.md でツール案内を **Claude Code / Codex 両対応**に
- slide.md の冒頭に **リポジトリ clone と作業ディレクトリの用意** スライドも追加（参加者が `@prompts/<言語>.md` を参照する手順を明示）

## 追加した拡張プロンプト

| 拡張                  | プロンプト                       | 触る場所                  | 達成感                       |
| --------------------- | -------------------------------- | ------------------------- | ---------------------------- |
| `break` / `continue`  | `prompts/ext-break-continue.md`  | Lexer/Parser/AST/CodeGen  | basic block の感触◎          |
| `&&` / `\|\|` / `!`   | `prompts/ext-logical-ops.md`     | Lexer/Parser/AST/CodeGen  | **短絡評価**を IR で表現     |
| C 風 `for`            | `prompts/ext-for-loop.md`        | Lexer/Parser (+ CodeGen)  | while への desugar 体験      |
| `string + string`     | `prompts/ext-string-concat.md`   | TypeCheck/CodeGen         | 外部ランタイム関数の呼び出し |

特に `ext-logical-ops.md` には**短絡評価の LLVM IR パターン**（phi 版 / alloca 版）、`ext-string-concat.md` には **strlen/malloc/strcpy/strcat シーケンス**を IR 例で同梱しています。

## Test plan

- [x] 4 つの `prompts/ext-*.md` が `prompts/` に存在
- [x] slide.md の後半 30 分が「言語拡張チャレンジ」に差し替わっている
- [x] slide.md / README.md で Claude Code / Codex が併記されている
- [x] slide.md にリポジトリ clone 手順と作業ディレクトリ用意のスライドが入っている
- [x] （任意）参考実装 `langs/<言語>/` で実際に各拡張を Claude Code/Codex に投げて 30 分以内に通るか試走